### PR TITLE
fix for #63 Prompt user if they are going to overwrite print continuity

### DIFF
--- a/src/calchartdoc.cpp
+++ b/src/calchartdoc.cpp
@@ -532,3 +532,8 @@ CalChartDoc::RestoreSnapShot(const CC_show& snapshot)
 	mShow.reset(new CC_show(snapshot));
 }
 
+bool
+CalChartDoc::AlreadyHasPrintContinuity() const
+{
+	return mShow->AlreadyHasPrintContinuity();
+}

--- a/src/calchartdoc.h
+++ b/src/calchartdoc.h
@@ -161,6 +161,8 @@ public:
 	const ShowMode& GetMode() const;
 	void SetMode(const ShowMode* m);
 
+	bool AlreadyHasPrintContinuity() const;
+
 private:
 	// Autosaving:
 	// goal is to allow the user to have a recoverable file.

--- a/src/core/cc_show.cpp
+++ b/src/core/cc_show.cpp
@@ -467,6 +467,19 @@ std::string CC_show::GetPointLabel(unsigned i) const
 }
 
 
+bool CC_show::AlreadyHasPrintContinuity() const
+{
+	for (auto& i : sheets)
+	{
+		if (i.GetPrintableContinuity().size() > 0)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+
 bool CC_show::SelectAll()
 {
 	bool changed = selectionList.size() != numpoints;

--- a/src/core/cc_show.h
+++ b/src/core/cc_show.h
@@ -105,6 +105,8 @@ public:
 	void SetPointLabel(const std::vector<std::string>& labels) { pt_labels = labels; }
 	inline const std::vector<std::string>& GetPointLabels() const { return pt_labels; }
 
+	bool AlreadyHasPrintContinuity() const;
+
 	// how to select points:
 	// Always select or unselect in groups
 	bool SelectAll();

--- a/src/field_view.cpp
+++ b/src/field_view.cpp
@@ -309,7 +309,19 @@ FieldView::DoImportPrintableContinuity(const wxString& file)
 	{
 		lines.push_back(fp.GetLine(line).ToStdString());
 	}
-	
+	auto hasCont = mShow->AlreadyHasPrintContinuity();
+	if (hasCont)
+	{
+		// prompt the user to find out if they would like to continue
+		int userchoice = wxMessageBox(
+									  wxT("This show already has some Printable Continuity.")
+									  wxT("Would you like to continue Importing Printable Continuity and overwrite it?"),
+									  wxT("Overwrite Printable Continuity?"), wxYES_NO|wxCANCEL);
+		if (userchoice != wxYES)
+		{
+			return true;
+		}
+	}
 	auto result = GetDocument()->GetCommandProcessor()->Submit(new ImportPrintContinuityCommand(*mShow, lines));
 	return result;
 }


### PR DESCRIPTION
This is a fix for #63 
Added a way to check if the print continuity is already there.  If it is, let the user decide if they want to continue.
