### PR TITLE
Ctrl+Click+Drag Scrolling (#66)

### DIFF
--- a/src/basic_ui.cpp
+++ b/src/basic_ui.cpp
@@ -91,9 +91,9 @@ ScrollZoomCanvas::ScrollZoomCanvas(wxWindow *parent,
 								   const wxSize& size,
 								   long style) :
 wxScrolledWindow(parent, id, pos, size, wxHSCROLL | wxVSCROLL | style),
-mZoomFactor(1.0),
 mOrigin(0, 0),
-mOffset(0, 0)
+mOffset(0, 0),
+mZoomFactor(1.0)
 {
 }
 
@@ -175,7 +175,7 @@ MouseMoveScrollCanvas::MouseMoveScrollCanvas(wxWindow *parent,
 	const wxPoint& pos,
 	const wxSize& size,
 	long style) :
-ScrollZoomCanvas(parent, id, pos, size, wxHSCROLL | wxVSCROLL | style),
+super(parent, id, pos, size, wxHSCROLL | wxVSCROLL | style),
 mLastPos(0, 0),
 mScrolledLastMove(false)
 {
@@ -195,13 +195,13 @@ MouseMoveScrollCanvas::OnMouseMove(wxMouseEvent &event)
 	if (ShouldScrollOnMouseEvent(event))
 	{
 		wxPoint changeInOffset = thisPos - mLastPos;
-		ChangeOffset(changeInOffset * GetScrollFactor());
+		ChangeOffset(changeInOffset);
 		mScrolledLastMove = true;
 	}
 	mLastPos = thisPos;
 }
 
-bool MouseMoveScrollCanvas::IsScrolling()
+bool MouseMoveScrollCanvas::IsScrolling() const
 {
 	return mScrolledLastMove;
 }
@@ -211,7 +211,7 @@ CtrlScrollCanvas::CtrlScrollCanvas(wxWindow *parent,
 	const wxPoint& pos,
 	const wxSize& size,
 	long style) :
-MouseMoveScrollCanvas(parent, id, pos, size, wxHSCROLL | wxVSCROLL | style)
+super(parent, id, pos, size, wxHSCROLL | wxVSCROLL | style)
 {
 }
 
@@ -220,14 +220,9 @@ CtrlScrollCanvas::~CtrlScrollCanvas()
 {
 }
 
-bool CtrlScrollCanvas::ShouldScrollOnMouseEvent(wxMouseEvent &event)
+bool CtrlScrollCanvas::ShouldScrollOnMouseEvent(const wxMouseEvent &event) const
 {
 	return event.ControlDown();
-}
-
-float CtrlScrollCanvas::GetScrollFactor()
-{
-	return 1.0;
 }
 
 
@@ -236,7 +231,7 @@ ClickDragCtrlScrollCanvas::ClickDragCtrlScrollCanvas(wxWindow *parent,
 	const wxPoint& pos,
 	const wxSize& size,
 	long style) :
-CtrlScrollCanvas(parent, id, pos, size, wxHSCROLL | wxVSCROLL | style)
+super(parent, id, pos, size, wxHSCROLL | wxVSCROLL | style)
 {
 }
 
@@ -245,7 +240,7 @@ ClickDragCtrlScrollCanvas::~ClickDragCtrlScrollCanvas()
 {
 }
 
-bool ClickDragCtrlScrollCanvas::ShouldScrollOnMouseEvent(wxMouseEvent &event)
+bool ClickDragCtrlScrollCanvas::ShouldScrollOnMouseEvent(const wxMouseEvent &event) const
 {
-	return event.Dragging() && CtrlScrollCanvas::ShouldScrollOnMouseEvent(event);
+	return event.Dragging() && super::ShouldScrollOnMouseEvent(event);
 }

--- a/src/basic_ui.h
+++ b/src/basic_ui.h
@@ -52,8 +52,7 @@ public:
  */
 class ScrollZoomCanvas : public wxScrolledWindow
 {
-private:
-	typedef wxScrolledWindow super;
+	using super = wxScrolledWindow;
 public:
 	ScrollZoomCanvas(wxWindow *parent,
 		wxWindowID id = wxID_ANY,
@@ -66,17 +65,17 @@ protected:
 	void PrepareDC(wxDC&);
 
 public:
-	virtual void SetZoom(float z);
-	virtual float GetZoom() const;
+	void SetZoom(float z);
+	float GetZoom() const;
 
-	virtual void SetOffset(wxPoint newOffset);
-	virtual void ChangeOffset(wxPoint deltaOffset);
-	virtual wxPoint GetOffset() const;
-	virtual void ResetScrollToOrigin();
+	void SetOffset(wxPoint newOffset);
+	void ChangeOffset(wxPoint deltaOffset);
+	wxPoint GetOffset() const;
+	void ResetScrollToOrigin();
 
-	virtual void SetOffsetOrigin(wxPoint newOrigin);
-	virtual void ChangeOffsetOrigin(wxPoint deltaOrigin);
-	virtual wxPoint GetOffsetOrigin() const;
+	void SetOffsetOrigin(wxPoint newOrigin);
+	void ChangeOffsetOrigin(wxPoint deltaOrigin);
+	wxPoint GetOffsetOrigin() const;
 private:
 	wxPoint mOrigin;
 	wxPoint mOffset;
@@ -90,6 +89,7 @@ private:
  */
 class MouseMoveScrollCanvas : public ScrollZoomCanvas
 {
+	using super = ScrollZoomCanvas;
 public:
 	MouseMoveScrollCanvas(wxWindow *parent,
 					 wxWindowID id = wxID_ANY,
@@ -100,10 +100,9 @@ public:
 public:
 	// Inform the ctrl scrolling when the mouse moves
     virtual void OnMouseMove(wxMouseEvent &event);
-	virtual bool IsScrolling();
+	virtual bool IsScrolling() const;
 protected:
-	virtual bool ShouldScrollOnMouseEvent(wxMouseEvent &event) = 0;
-	virtual float GetScrollFactor() = 0;
+	virtual bool ShouldScrollOnMouseEvent(const wxMouseEvent &event) const = 0;
 private:
 	wxPoint mLastPos;
 	bool mScrolledLastMove;
@@ -114,6 +113,7 @@ private:
  */
 class CtrlScrollCanvas : public MouseMoveScrollCanvas
 {
+	using super = MouseMoveScrollCanvas;
 public:
 	CtrlScrollCanvas(wxWindow *parent,
 		wxWindowID id = wxID_ANY,
@@ -122,12 +122,7 @@ public:
 		long style = 0);
 	virtual ~CtrlScrollCanvas();
 protected:
-	virtual bool ShouldScrollOnMouseEvent(wxMouseEvent &event);
-	virtual float GetScrollFactor();
-private:
-	wxPoint mOffset;
-	wxPoint mLastPos;
-	float mZoomFactor;
+	virtual bool ShouldScrollOnMouseEvent(const wxMouseEvent &event) const;
 };
 
 /**
@@ -135,6 +130,7 @@ private:
  */
 class ClickDragCtrlScrollCanvas : public CtrlScrollCanvas
 {
+	using super = CtrlScrollCanvas;
 public:
 	ClickDragCtrlScrollCanvas(wxWindow *parent,
 		wxWindowID id = wxID_ANY,
@@ -143,7 +139,7 @@ public:
 		long style = 0);
 	virtual ~ClickDragCtrlScrollCanvas();
 protected:
-	virtual bool ShouldScrollOnMouseEvent(wxMouseEvent &event);
+	virtual bool ShouldScrollOnMouseEvent(const wxMouseEvent &event) const;
 };
 
 #endif

--- a/src/field_canvas.cpp
+++ b/src/field_canvas.cpp
@@ -511,7 +511,7 @@ FieldCanvas::OnMouseRightDown(wxMouseEvent& event)
 void
 FieldCanvas::OnMouseMove(wxMouseEvent& event)
 {
-	ClickDragCtrlScrollCanvas::OnMouseMove(event);
+	super::OnMouseMove(event);
 	
 	if (!IsScrolling())
 	{

--- a/src/field_canvas.h
+++ b/src/field_canvas.h
@@ -40,6 +40,7 @@ class CC_coord;
 // Field Canvas controls how to paint and the first line control of user input
 class FieldCanvas : public ClickDragCtrlScrollCanvas
 {
+	using super = ClickDragCtrlScrollCanvas;
 public:
 // Basic functions
 	FieldCanvas(wxView *view, FieldFrame *frame, float def_zoom);


### PR DESCRIPTION
Stunt would prefer to scroll the field canvas by clicking and dragging the
mouse while holding down control (instead of just holding down ctrl) -
this commit makes that happen, but there's something for us to keep note
of for the future: if you click to drag the canvas, but you click on a
dot, it will select that dot. That is, when you drag, the current tool
that you are using is not disabled. This shouldn't be a big deal, but I
have plans to fix this up in the future.
