### PR TITLE
Fix for #69

### DIFF
--- a/src/cont_ui.cpp
+++ b/src/cont_ui.cpp
@@ -257,7 +257,7 @@ void ContinuityEditor::SetInsertionPoint(int x, int y)
 
 SYMBOL_TYPE ContinuityEditor::CurrentSymbolChoice() const
 {
-	auto name = mContinuityChoices->GetString(mContinuityChoices->GetSelection());
+	auto name = mContinuityChoices->GetString(mCurrentContinuityChoice);
 	return GetSymbolForName(name.ToStdString());
 }
 


### PR DESCRIPTION
After the selected dot type was changed through the pull down menu, and the user said "yes" to the prompt asking if he/she wanted to safe changes, the continuity editor would save the changes to the currently selected dot type in the pull down menu. Since the continuity change is actually relevant to the previously selected dot type, it would save changes to the wrong dot type. This should fix that though.
