### PR TITLE
Fix for #20: MAC: Crash when quitting from the help menu

### DIFF
--- a/src/calchartapp.cpp
+++ b/src/calchartapp.cpp
@@ -37,13 +37,6 @@
 
 wxPrintDialogData *gPrintDialogData;
 
-wxHtmlHelpController&
-GetGlobalHelpController()
-{
-	static wxHtmlHelpController sHelpController;
-	return sHelpController;
-}
-
 void CC_continuity_UnitTests();
 void CC_point_UnitTests();
 void CC_coord_UnitTests();
@@ -63,6 +56,7 @@ bool CalChartApp::OnInit()
 			CLASSINFO(CalChartDoc), CLASSINFO(FieldView));
 
 	gPrintDialogData = new wxPrintDialogData();
+	mHelpController = std::unique_ptr<wxHtmlHelpController>(new wxHtmlHelpController());
 
 	// setup the configuration.
 	ReadConfig();
@@ -107,6 +101,12 @@ bool CalChartApp::OnInit()
 	return true;
 }
 
+wxHtmlHelpController&
+CalChartApp::GetGlobalHelpController()
+{
+	return *mHelpController;
+}
+
 void CalChartApp::MacOpenFile(const wxString &fileName)
 {
 	mDocManager->CreateDocument(fileName, wxDOC_SILENT);
@@ -125,6 +125,8 @@ int CalChartApp::OnExit()
     // delete the doc manager
     delete wxDocManager::GetDocumentManager();
     
+	mHelpController.reset();
+
 	return wxApp::OnExit();
 }
 

--- a/src/calchartapp.h
+++ b/src/calchartapp.h
@@ -27,13 +27,11 @@
 
 #include <wx/wx.h>
 #include <wx/docview.h>
+#include <memory>
 
 class CalChartApp;
 class ShowMode;
 class wxHtmlHelpController;
-
-// the global help system:
-wxHtmlHelpController& GetGlobalHelpController();
 
 DECLARE_APP(CalChartApp)
 
@@ -46,10 +44,15 @@ public:
 	int OnExit();
 
 	ShowModeList& GetModeList() { return mModeList; }
+
+	// the global help system:
+	wxHtmlHelpController& GetGlobalHelpController();
+	
 private:
 	ShowModeList mModeList;
 
 	wxDocManager* mDocManager;
+	std::unique_ptr<wxHtmlHelpController> mHelpController;
 };
 
 #endif // _CALCHARTAPP_H_

--- a/src/cont_ui.cpp
+++ b/src/cont_ui.cpp
@@ -224,8 +224,8 @@ void ContinuityEditor::OnCloseWindow(wxCommandEvent& event)
 
 void ContinuityEditor::OnCmdHelp(wxCommandEvent& event)
 {
-	GetGlobalHelpController().LoadFile();
-	GetGlobalHelpController().KeywordSearch(wxT("Animation Commands"));
+	wxGetApp().GetGlobalHelpController().LoadFile();
+	wxGetApp().GetGlobalHelpController().KeywordSearch(wxT("Animation Commands"));
 }
 
 

--- a/src/print_cont_ui.cpp
+++ b/src/print_cont_ui.cpp
@@ -253,8 +253,8 @@ void PrintContinuityEditor::OnCloseWindow(wxCommandEvent& event)
 
 void PrintContinuityEditor::OnCmdHelp(wxCommandEvent& event)
 {
-	GetGlobalHelpController().LoadFile();
-	GetGlobalHelpController().KeywordSearch(wxT("Animation Commands"));
+	wxGetApp().GetGlobalHelpController().LoadFile();
+	wxGetApp().GetGlobalHelpController().KeywordSearch(wxT("Animation Commands"));
 }
 
 

--- a/src/top_frame.cpp
+++ b/src/top_frame.cpp
@@ -139,8 +139,8 @@ TopFrame::About()
 void
 TopFrame::Help()
 {
-	GetGlobalHelpController().LoadFile();
-	GetGlobalHelpController().DisplayContents();
+	wxGetApp().GetGlobalHelpController().LoadFile();
+	wxGetApp().GetGlobalHelpController().DisplayContents();
 }
 
 


### PR DESCRIPTION
Making sure we delete the help controller on exit.  This ensure that the controller doesn't try to access the config system which may already be closed.
