### PR TITLE
Ghost View Color Pen Width Fix

### DIFF
--- a/src/confgr.cpp
+++ b/src/confgr.cpp
@@ -115,6 +115,10 @@ const int DefaultPenWidth[COLOR_NUM] =
 	1,
 	1,
 	1,
+	1,
+	1,
+	1,
+	1,
 	2,
 };
 


### PR DESCRIPTION
This hasn't caused any problems yet, but could in the future.
I forgot to add default pen widths for the Ghost View colors, so here they are.
