### PR TITLE
Fixed: CalChart didn't properly report number of selected dots after lasso select

### DIFF
--- a/src/calchartdoc.cpp
+++ b/src/calchartdoc.cpp
@@ -497,6 +497,7 @@ void CalChartDoc::ToggleSelection(const SelectionList& sl)
 void CalChartDoc::SelectWithLasso(const CC_lasso& lasso, bool toggleSelected, unsigned ref)
 {
 	mShow->SelectWithLasso(lasso, toggleSelected, ref);
+	UpdateAllViews();
 }
 
 bool CalChartDoc::IsSelected(unsigned i) const { return mShow->IsSelected(i); }


### PR DESCRIPTION
Fix for #92 
