### PR TITLE
Fix for #96: Unhandled Exceptions in Continuity Editor

### DIFF
--- a/src/cont_ui.cpp
+++ b/src/cont_ui.cpp
@@ -301,6 +301,9 @@ void ContinuityEditor::FlushText()
 void ContinuityEditor::SetCurrent(unsigned i)
 {
 	mCurrentContinuityChoice = i;
+	if (mCurrentContinuityChoice >= mContinuityChoices->GetCount()) {
+		mCurrentContinuityChoice = mContinuityChoices->GetCount() - 1;
+	}
 	mContinuityChoices->SetSelection(mCurrentContinuityChoice);
 	UpdateText();
 }


### PR DESCRIPTION
Check out #96 for details about the issue.
The problem was that when the Continuity Editor saves, it deletes dot types from its list that have no dots or continuities associated with them. So, for example, if you delete the continuity for unused dot type "solid", and then switch to the last dot type ("X") while allowing the continuity editor to save your changes, it first deletes the "solid" option (option with index 2), and then tries to switch to dot type "X" (option with index 3). Since the continuity editor removed the "solid" option, however, the index of dot type "X" has been reduced to 2. Now the continuity editor is trying to access an option at index 3, when the highest option it has is at index 2. 
This fix resolves the problem by clipping the index of the target dot type, so that it is never larger than the max dot type index.
