### PR TITLE
removing \& from all 'Close' commands.  Close should now only be cmd-w i...

### DIFF
--- a/src/animation_frame.cpp
+++ b/src/animation_frame.cpp
@@ -100,7 +100,7 @@ mWhenClosed(onClose)
 	wxMenu *anim_menu = new wxMenu;
 	anim_menu->Append(CALCHART__anim_reanimate, wxT("&Reanimate Show...\tCTRL-RETURN"), wxT("Regenerate animation"));
 	anim_menu->Append(CALCHART__anim_select_coll, wxT("&Select Collisions"), wxT("Select colliding points"));
-	anim_menu->Append(wxID_CLOSE, wxT("&Close Window\tCTRL-W"), wxT("Close window"));
+	anim_menu->Append(wxID_CLOSE, wxT("Close Window\tCTRL-W"), wxT("Close window"));
 
 	
 	wxMenuBar *menu_bar = new wxMenuBar;

--- a/src/cont_ui.cpp
+++ b/src/cont_ui.cpp
@@ -140,7 +140,7 @@ void ContinuityEditor::CreateControls()
 	wxMenu *cont_menu = new wxMenu;
 	cont_menu->Append(ContinuityEditor_Save, wxT("&Save Continuity\tCTRL-S"), wxT("Save continuity"));
 	cont_menu->Append(ContinuityEditor_ContEditSelect, wxT("Select &Points\tCTRL-P"), wxT("Select Points"));
-	cont_menu->Append(wxID_CLOSE, wxT("&Close Window\tCTRL-W"), wxT("Close this window"));
+	cont_menu->Append(wxID_CLOSE, wxT("Close Window\tCTRL-W"), wxT("Close this window"));
 
 	wxMenu *help_menu = new wxMenu;
 	help_menu->Append(wxID_HELP, wxT("&Help on Continuity...\tCTRL-H"), wxT("Help on Continuity"));
@@ -180,7 +180,7 @@ void ContinuityEditor::CreateControls()
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	button = new wxButton(this, ContinuityEditor_Discard, wxT("&Discard"));
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	button = new wxButton(this, wxID_CLOSE, wxT("&Close"));
+	button = new wxButton(this, wxID_CLOSE, wxT("Close"));
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	button = new wxButton(this, wxID_HELP, wxT("&Help"));
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );

--- a/src/field_frame.cpp
+++ b/src/field_frame.cpp
@@ -226,7 +226,7 @@ config(config_)
 	file_menu->Append(CALCHART__LEGACY_PRINT, wxT("Print to PS..."), wxT("Print show to PostScript"));
 	file_menu->Append(CALCHART__LEGACY_PRINT_EPS, wxT("Print to EPS..."), wxT("Print show to Encapsulated PostScript"));
 	file_menu->Append(wxID_PREFERENCES, wxT("&Preferences\tCTRL-,"));
-	file_menu->Append(wxID_CLOSE, wxT("&Close Window\tCTRL-W"), wxT("Close this window"));
+	file_menu->Append(wxID_CLOSE, wxT("Close Window\tCTRL-W"), wxT("Close this window"));
 	file_menu->Append(wxID_EXIT, wxT("&Quit\tCTRL-Q"), wxT("Quit CalChart"));
 
 	// A nice touch: a history of files visited. Use this menu.

--- a/src/print_cont_ui.cpp
+++ b/src/print_cont_ui.cpp
@@ -155,7 +155,7 @@ void PrintContinuityEditor::CreateControls()
 	// menu bar
 	wxMenu *cont_menu = new wxMenu;
 	cont_menu->Append(PrintContinuityEditor_Save, wxT("&Save Continuity\tCTRL-S"), wxT("Save continuity"));
-	cont_menu->Append(wxID_CLOSE, wxT("&Close Window\tCTRL-W"), wxT("Close this window"));
+	cont_menu->Append(wxID_CLOSE, wxT("Close Window\tCTRL-W"), wxT("Close this window"));
 
 	wxMenu *help_menu = new wxMenu;
 	help_menu->Append(wxID_HELP, wxT("&Help on Continuity...\tCTRL-H"), wxT("Help on Continuity"));
@@ -209,7 +209,7 @@ void PrintContinuityEditor::CreateControls()
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	button = new wxButton(this, PrintContinuityEditor_Discard, wxT("&Discard"));
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
-	button = new wxButton(this, wxID_CLOSE, wxT("&Close"));
+	button = new wxButton(this, wxID_CLOSE, wxT("Close"));
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );
 	button = new wxButton(this, wxID_HELP, wxT("&Help"));
 	top_button_sizer->Add(button, 0, wxALIGN_CENTER_VERTICAL|wxALL, 5 );


### PR DESCRIPTION
...nstead of also cmd-c.

Checked on mac.  Probably need to check that this works on Windows.

I fixed this for Continuity editor, print continuity editor, and also animation screen.

This should address issue #98 
