### PR TITLE
32: Make sure different versions play nicely

### DIFF
--- a/src/calchartapp.cpp
+++ b/src/calchartapp.cpp
@@ -40,6 +40,8 @@ wxPrintDialogData *gPrintDialogData;
 void CC_continuity_UnitTests();
 void CC_point_UnitTests();
 void CC_coord_UnitTests();
+void CC_show_UnitTests();
+void CC_sheet_UnitTests();
 
 // This statement initializes the whole application and calls OnInit
 IMPLEMENT_APP(CalChartApp)
@@ -135,6 +137,8 @@ void CalChartApp::InitAppAsServer() {
 	CC_continuity_UnitTests();
 	CC_point_UnitTests();
 	CC_coord_UnitTests();
+	CC_show_UnitTests();
+	CC_sheet_UnitTests();
 
 
 	ProcessArguments();

--- a/src/core/cc_point.cpp
+++ b/src/core/cc_point.cpp
@@ -96,52 +96,37 @@ CC_point::Serialize() const
 			++num_ref_pts;
 		}
 	}
-	uint8_t size_of_each_point_data = (num_ref_pts * 5) + 2 + 2 + 1 + 1 + 1;
-
+	std::vector<uint8_t> result;
 	// Point positions
-	std::ostringstream stream("");
-
 	// Write block size
-	Write(stream, &size_of_each_point_data, sizeof(size_of_each_point_data));
 
-	// Write POSITION
-	Coord crd;
-	put_big_word(&crd, GetPos().x);
-	Write(stream, &crd, 2);
-	put_big_word(&crd, GetPos().y);
-	Write(stream, &crd, 2);
+	// Write POSITIONw
+	CalChart::Parser::Append(result, uint16_t(GetPos().x));
+	CalChart::Parser::Append(result, uint16_t(GetPos().y));
 
 	// Write REF_POS
-	Write(stream, &num_ref_pts, 1);
+	CalChart::Parser::Append(result, uint8_t(num_ref_pts));
 	if (num_ref_pts)
 	{
 		for (auto j = 1; j <= CC_point::kNumRefPoints; j++)
 		{
 			if (GetPos(j) != GetPos(0))
 			{
-				uint8_t which = j;
-				Write(stream, &which, 1);
-				Coord crd;
-				put_big_word(&crd, GetPos(j).x);
-				Write(stream, &crd, 2);
-				put_big_word(&crd, GetPos(j).y);
-				Write(stream, &crd, 2);
+				CalChart::Parser::Append(result, uint8_t(j));
+				CalChart::Parser::Append(result, uint16_t(GetPos(j).x));
+				CalChart::Parser::Append(result, uint16_t(GetPos(j).y));
 			}
 		}
 	}
 
 	// Write POSITION
-	uint8_t tmp = GetSymbol();
-	Write(stream, &tmp, 1);
+	CalChart::Parser::Append(result, uint8_t(GetSymbol()));
 
 	// Point labels (left or right)
-	tmp = (GetFlip()) ? true : false;
-	Write(stream, &tmp, 1);
+	CalChart::Parser::Append(result, uint8_t(GetFlip()));
+	result.insert(result.begin(), uint8_t(result.size()));
 
-	auto sdata = stream.str();
-	std::vector<uint8_t> data;
-	std::copy(sdata.begin(), sdata.end(), std::back_inserter(data));
-	return data;
+	return result;
 }
 
 bool

--- a/src/core/cc_sheet.h
+++ b/src/core/cc_sheet.h
@@ -27,6 +27,7 @@
 #include "cc_continuity.h"
 #include "cc_point.h"
 #include "cc_text.h"
+#include "cc_fileformat.h"
 
 #include <vector>
 #include <set>
@@ -44,10 +45,10 @@ class CC_point;
 class CC_sheet
 {
 public:
-	CC_sheet(CC_show *shw);
+	CC_sheet(size_t numPoints);
+	CC_sheet(size_t numPoints, const std::string& newname);
 	CC_sheet(size_t numPoints, std::istream& stream, Version_3_3_and_earlier);
-	CC_sheet(size_t numPoints, std::istream& stream, Current_version_and_later);
-	CC_sheet(CC_show *shw, const std::string& newname);
+	CC_sheet(size_t numPoints, const uint8_t* ptr, size_t size, Current_version_and_later);
 	~CC_sheet();
 
 private:
@@ -109,6 +110,12 @@ private:
 	unsigned short beats;
 	std::vector<CC_point> pts;
 	std::string mName;
+
+	// unit tests
+	friend void CC_sheet_UnitTests();
+	static void CC_sheet_round_trip_test();
 };
+
+void CC_sheet_UnitTests();
 
 #endif

--- a/src/core/cc_show.h
+++ b/src/core/cc_show.h
@@ -24,6 +24,7 @@
 #define _CC_SHOW_H_
 
 #include "cc_types.h"
+#include "cc_fileformat.h"
 
 #include <vector>
 #include <string>
@@ -54,7 +55,7 @@ public:
 	typedef CC_sheet_container_t::iterator CC_sheet_iterator_t;
 	typedef CC_sheet_container_t::const_iterator const_CC_sheet_iterator_t;
 
-	// you can create a show in two ways, from scratch, or from an input stream
+	// you can create a show in two ways, from nothing, or from an input stream
 	static std::unique_ptr<CC_show> Create_CC_show();
 	static std::unique_ptr<CC_show> Create_CC_show(std::istream& stream);
 
@@ -62,7 +63,7 @@ private:
 	CC_show();
 	// using overloading with structs to determine which constructor to use
 	CC_show(std::istream& stream, Version_3_3_and_earlier);
-	CC_show(std::istream& stream, Current_version_and_later);
+	CC_show(const uint8_t* ptr, size_t size, Current_version_and_later);
 
 public:
 	~CC_show();
@@ -126,6 +127,21 @@ private:
 	std::vector<std::string> pt_labels;
 	SelectionList selectionList;	  // order of selections
 	unsigned mSheetNum;
+
+	// unit tests
+	friend void CC_show_UnitTests();
+	static void CC_show_round_trip_test();
+	static void CC_show_round_trip_test_with_number_label_description();
+	static void CC_show_blank_desc_test();
+	static void CC_show_future_show_test();
+	static void CC_show_wrong_size_throws_exception();
+	static void CC_show_wrong_size_number_labels_throws();
+	static void CC_show_wrong_size_description();
+	static void CC_show_extra_cruft_ok();
+	static void CC_show_with_nothing_throws();
+
 };
+
+void CC_show_UnitTests();
 
 #endif // _CC_SHOW_H_

--- a/src/core/cc_types.h
+++ b/src/core/cc_types.h
@@ -65,30 +65,4 @@ enum CC_MOVE_MODES
 
 typedef std::set<unsigned> SelectionList;
 
-#define Make4CharWord(a,b,c,d) (((a) << 24) | ((b) << 16) | ((c) << 8) | (d))
-
-#define INGL_INGL Make4CharWord('I','N','G','L')
-#define INGL_GURK Make4CharWord('G','U','R','K')
-#define INGL_SHOW Make4CharWord('S','H','O','W')
-#define INGL_SHET Make4CharWord('S','H','E','T')
-#define INGL_SIZE Make4CharWord('S','I','Z','E')
-#define INGL_LABL Make4CharWord('L','A','B','L')
-#define INGL_MODE Make4CharWord('M','O','D','E')
-#define INGL_DESC Make4CharWord('D','E','S','C')
-#define INGL_NAME Make4CharWord('N','A','M','E')
-#define INGL_DURA Make4CharWord('D','U','R','A')
-#define INGL_POS  Make4CharWord('P','O','S',' ')
-#define INGL_SYMB Make4CharWord('S','Y','M','B')
-#define INGL_TYPE Make4CharWord('T','Y','P','E')
-#define INGL_REFP Make4CharWord('R','E','F','P')
-#define INGL_CONT Make4CharWord('C','O','N','T')
-#define INGL_ECNT Make4CharWord('E','C','N','T')
-#define INGL_PCNT Make4CharWord('P','C','N','T')
-#define INGL_PNTS Make4CharWord('P','N','T','S')
-#define INGL_PONT Make4CharWord('P','O','N','T')
-#define INGL_END  Make4CharWord('E','N','D',' ')
-
-struct Version_3_3_and_earlier {};
-struct Current_version_and_later {};
-
 #endif

--- a/src/field_frame.cpp
+++ b/src/field_frame.cpp
@@ -625,7 +625,13 @@ void FieldFrame::OnCmdPasteSheet(wxCommandEvent& event) {
 
 			ReadLong(sheetStream);
 			ReadLong(sheetStream);
-			CC_show::CC_sheet_container_t sht(1, CC_sheet(numPoints, sheetStream, Current_version_and_later()));
+
+			sheetStream.unsetf(std::ios_base::skipws);
+			std::istream_iterator<uint8_t> theBegin(sheetStream);
+			std::istream_iterator<uint8_t> theEnd{};
+			std::vector<uint8_t> data(theBegin, theEnd);
+
+			CC_show::CC_sheet_container_t sht(1, CC_sheet(numPoints, data.data(), data.size(), Current_version_and_later()));
 			GetFieldView()->DoInsertSheets(sht, GetFieldView()->GetCurrentSheetNum());
 		}
 		wxTheClipboard->Close();


### PR DESCRIPTION
Adding parsing lambdas.  What this does is allow you to bypass extra values that aren't known, so an older version of calchart might be able to open shows saved by a new version.

This addresses #32 
