### PR TITLE
Precompiled Headers are back! (also some visual studio compiler error fixes)

### DIFF
--- a/build-win/CalChart/CalChart.vcxproj
+++ b/build-win/CalChart/CalChart.vcxproj
@@ -46,6 +46,9 @@
       <AdditionalIncludeDirectories>$(WXWIN)\include;$(WXWIN)\include\msvc;..\..\resources;..\..\src;..\..\src\core</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;WINVER=0x0400;__WXMSW__;_WINDOWS;wxUSE_GUI=1;_UNICODE;_DEBUG;__WXDEBUG__;_CRT_SECURE_NO_DEPRECATE;_CRT_NONSTDC_NO_DEPRECATE;YY_NO_UNISTD_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>precomp.h</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -119,6 +122,7 @@
     <ClInclude Include="..\..\src\linmath.h" />
     <ClInclude Include="..\..\src\modes.h" />
     <ClInclude Include="..\..\src\platconf.h" />
+    <ClInclude Include="..\..\src\precomp.h" />
     <ClInclude Include="..\..\src\print_cont_ui.h" />
     <ClInclude Include="..\..\src\print_ps.h" />
     <ClInclude Include="..\..\src\print_ps_dialog.h" />
@@ -162,6 +166,9 @@
     <ClCompile Include="..\..\src\field_view.cpp" />
     <ClCompile Include="..\..\src\ghost_module.cpp" />
     <ClCompile Include="..\..\src\modes.cpp" />
+    <ClCompile Include="..\..\src\precomp.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\..\src\print_cont_ui.cpp" />
     <ClCompile Include="..\..\src\print_ps.cpp" />
     <ClCompile Include="..\..\src\print_ps_dialog.cpp" />

--- a/build-win/CalChart/CalChart.vcxproj.filters
+++ b/build-win/CalChart/CalChart.vcxproj.filters
@@ -65,6 +65,7 @@
     <ClCompile Include="..\..\src\print_cont_ui.cpp" />
     <ClCompile Include="..\..\src\single_instance_ipc.cpp" />
     <ClCompile Include="..\..\src\ghost_module.cpp" />
+    <ClCompile Include="..\..\src\precomp.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\animation_canvas.h" />
@@ -141,6 +142,7 @@
     <ClInclude Include="..\..\src\single_instance_ipc.h" />
     <ClInclude Include="..\..\src\ghost_module.h" />
     <ClInclude Include="..\..\src\draw.h" />
+    <ClInclude Include="..\..\src\precomp.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\calchart.rc" />

--- a/src/cc_preferences_ui.cpp
+++ b/src/cc_preferences_ui.cpp
@@ -35,6 +35,7 @@
 #include <wx/statline.h>
 #include <wx/notebook.h>
 #include <wx/listbook.h>
+#include <wx/dcbuffer.h>
 
 // how the preferences work:
 // preference dialog create a copy of the CalChart config from which to read and set values

--- a/src/confgr.cpp
+++ b/src/confgr.cpp
@@ -38,31 +38,31 @@
 
 const std::tuple<wxString, wxString, int> ColorInfo[COLOR_NUM] =
 {
-	{ wxT("FIELD"),					wxT("FOREST GREEN"),	1 },
-	{ wxT("FIELD DETAIL"),			wxT("WHITE"),			1 },
-	{ wxT("FIELD TEXT"),			wxT("BLACK"),			1 },
-	{ wxT("POINT"),					wxT("WHITE"),			1 },
-	{ wxT("POINT TEXT"),			wxT("BLACK"),			1 },
-	{ wxT("HILIT POINT"),			wxT("YELLOW"),			1 },
-	{ wxT("HILIT POINT TEXT"),		wxT("YELLOW"),			1 },
-	{ wxT("REF POINT"),				wxT("PURPLE"),			1 },
-	{ wxT("REF POINT TEXT"),		wxT("BLACK"),			1 },
-	{ wxT("HILIT REF POINT"),		wxT("PURPLE"),			1 },
-	{ wxT("HILIT REF POINT TEXT"),		wxT("BLACK"),			1 },
-	{ wxT("GHOST POINT"),			wxT("BLUE"),			1 },
-	{ wxT("GHOST POINT TEXT"),		wxT("NAVY"),			1 },
-	{ wxT("HLIT GHOST POINT"),		wxT("PURPLE"),			1 },
-	{ wxT("HLIT GHOST POINT TEXT"),		wxT("PLUM"),			1 },
-	{ wxT("ANIM FRONT"),			wxT("WHITE"),			1 },
-	{ wxT("ANIM BACK"),				wxT("YELLOW"),			1 },
-	{ wxT("ANIM SIDE"),				wxT("SKY BLUE"),		1 },
-	{ wxT("HILIT ANIM FRONT"),		wxT("RED"),				1 },
-	{ wxT("HILIT ANIM BACK"),		wxT("RED"),				1 },
-	{ wxT("HILIT ANIM SIDE"),		wxT("RED"),				1 },
-	{ wxT("ANIM COLLISION"),		wxT("PURPLE"),			1 },
-	{ wxT("ANIM COLLISION WARNING"),	wxT("CORAL"),			1 },
-	{ wxT("SHAPES"),				wxT("ORANGE"),			2 },
-	{ wxT("CONTINUITY PATHS"),		wxT("RED"),				1 },
+	std::tuple<wxString, wxString, int>(wxT("FIELD"),					wxT("FOREST GREEN"),	1),
+	std::tuple<wxString, wxString, int>(wxT("FIELD DETAIL"),			wxT("WHITE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("FIELD TEXT"),				wxT("BLACK"),			1),
+	std::tuple<wxString, wxString, int>(wxT("POINT"),					wxT("WHITE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("POINT TEXT"),				wxT("BLACK"),			1),
+	std::tuple<wxString, wxString, int>(wxT("HILIT POINT"),				wxT("YELLOW"),			1),
+	std::tuple<wxString, wxString, int>(wxT("HILIT POINT TEXT"),		wxT("YELLOW"),			1),
+	std::tuple<wxString, wxString, int>(wxT("REF POINT"),				wxT("PURPLE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("REF POINT TEXT"),			wxT("BLACK"),			1),
+	std::tuple<wxString, wxString, int>(wxT("HILIT REF POINT"),			wxT("PURPLE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("HILIT REF POINT TEXT"),	wxT("BLACK"),			1),
+	std::tuple<wxString, wxString, int>(wxT("GHOST POINT"),				wxT("BLUE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("GHOST POINT TEXT"),		wxT("NAVY"),			1),
+	std::tuple<wxString, wxString, int>(wxT("HLIT GHOST POINT"),		wxT("PURPLE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("HLIT GHOST POINT TEXT"),	wxT("PLUM"),			1),
+	std::tuple<wxString, wxString, int>(wxT("ANIM FRONT"),				wxT("WHITE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("ANIM BACK"),				wxT("YELLOW"),			1),
+	std::tuple<wxString, wxString, int>(wxT("ANIM SIDE"),				wxT("SKY BLUE"),		1),
+	std::tuple<wxString, wxString, int>(wxT("HILIT ANIM FRONT"),		wxT("RED"),				1),
+	std::tuple<wxString, wxString, int>(wxT("HILIT ANIM BACK"),			wxT("RED"),				1),
+	std::tuple<wxString, wxString, int>(wxT("HILIT ANIM SIDE"),			wxT("RED"),				1),
+	std::tuple<wxString, wxString, int>(wxT("ANIM COLLISION"),			wxT("PURPLE"),			1),
+	std::tuple<wxString, wxString, int>(wxT("ANIM COLLISION WARNING"),	wxT("CORAL"),			1),
+	std::tuple<wxString, wxString, int>(wxT("SHAPES"),					wxT("ORANGE"),			2),
+	std::tuple<wxString, wxString, int>(wxT("CONTINUITY PATHS"),		wxT("RED"),				1),
 };
 
 ///// Show mode configuration /////
@@ -239,7 +239,7 @@ CalChartConfiguration::ColorWidth_t GetConfigValue(const wxString& key, const Ca
 	long w = std::get<1>(def);
 	w = GetConfigPathKey<long>(wxT("/COLORS/WIDTH"), key, w);
 
-	return { wxColour( r, g, b ), w };
+	return CalChartConfiguration::ColorWidth_t(wxColour( r, g, b ), w);
 }
 
 // Specialize on Color

--- a/src/core/cc_fileformat.h
+++ b/src/core/cc_fileformat.h
@@ -461,7 +461,7 @@ std::vector<std::tuple<uint32_t, Iter, size_t>> ParseOutLabels(Iter begin, Iter 
 		{
 			return result;
 		}
-		result.push_back({name, data, size});
+		result.push_back(std::tuple<uint32_t, Iter, size_t>(name, data, size));
 	}
 	return result;
 }

--- a/src/core/cc_sheet.cpp
+++ b/src/core/cc_sheet.cpp
@@ -30,6 +30,7 @@
 #include <map>
 #include <cctype>
 #include <algorithm>
+#include <functional>
 
 const std::string contnames[MAX_NUM_SYMBOLS] =
 {

--- a/src/core/cc_show.cpp
+++ b/src/core/cc_show.cpp
@@ -30,6 +30,7 @@
 #include "ccvers.h"
 
 #include <sstream>
+#include <functional>
 
 static const std::string k_nofile_str = "Unable to open file";
 static const std::string k_badcont_str = "Error in continuity file";

--- a/src/precomp.cpp
+++ b/src/precomp.cpp
@@ -1,0 +1,1 @@
+#include "precomp.h"

--- a/src/precomp.h
+++ b/src/precomp.h
@@ -1,0 +1,6 @@
+#ifndef _PRECOMP_H_
+#define _PRECOMP_H_
+
+#include <wx/wxprec.h>
+
+#endif


### PR DESCRIPTION
It's been a while since I've last had a chance to upload any commits to CalChart! This is refreshing!

I've redone the precompiled headers for windows, and I think this new version is much cleaner than the old one. Visual Studio is now set up to create a precompiled header for "precomp.h" and to link all other .cpp files in the project to it automatically. precomp.cpp exists for the purpose of making sure that Visual Studio automatically builds a precompiled header from precomp.h.

I had to make some other various changes to make sure that CalChart would build with Visual Studio. The main changes that I had to make were:
1. Visual Studio can't reference std::function without including the <functional> file
2. It seems that Visual Studio can't create tuple or pair objects directly from lists of items that are within curly braces
