### PR TITLE
Visual Studio Compile Fixes

### DIFF
--- a/build-win/CalChart/CalChart.vcxproj
+++ b/build-win/CalChart/CalChart.vcxproj
@@ -113,18 +113,18 @@
     <ClInclude Include="..\..\src\core\cc_types.h" />
     <ClInclude Include="..\..\src\core\cont.h" />
     <ClInclude Include="..\..\src\core\math_utils.h" />
+    <ClInclude Include="..\..\src\core\modes.h" />
     <ClInclude Include="..\..\src\core\parse.h" />
+    <ClInclude Include="..\..\src\core\print_ps.h" />
     <ClInclude Include="..\..\src\draw.h" />
     <ClInclude Include="..\..\src\field_canvas.h" />
     <ClInclude Include="..\..\src\field_frame.h" />
     <ClInclude Include="..\..\src\field_view.h" />
     <ClInclude Include="..\..\src\ghost_module.h" />
     <ClInclude Include="..\..\src\linmath.h" />
-    <ClInclude Include="..\..\src\modes.h" />
     <ClInclude Include="..\..\src\platconf.h" />
     <ClInclude Include="..\..\src\precomp.h" />
     <ClInclude Include="..\..\src\print_cont_ui.h" />
-    <ClInclude Include="..\..\src\print_ps.h" />
     <ClInclude Include="..\..\src\print_ps_dialog.h" />
     <ClInclude Include="..\..\src\setup_wizards.h" />
     <ClInclude Include="..\..\src\show_ui.h" />
@@ -160,17 +160,17 @@
     <ClCompile Include="..\..\src\core\cc_text.cpp" />
     <ClCompile Include="..\..\src\core\cont.cpp" />
     <ClCompile Include="..\..\src\core\math_utils.cpp" />
+    <ClCompile Include="..\..\src\core\modes.cpp" />
+    <ClCompile Include="..\..\src\core\print_ps.cpp" />
     <ClCompile Include="..\..\src\draw.cpp" />
     <ClCompile Include="..\..\src\field_canvas.cpp" />
     <ClCompile Include="..\..\src\field_frame.cpp" />
     <ClCompile Include="..\..\src\field_view.cpp" />
     <ClCompile Include="..\..\src\ghost_module.cpp" />
-    <ClCompile Include="..\..\src\modes.cpp" />
     <ClCompile Include="..\..\src\precomp.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="..\..\src\print_cont_ui.cpp" />
-    <ClCompile Include="..\..\src\print_ps.cpp" />
     <ClCompile Include="..\..\src\print_ps_dialog.cpp" />
     <ClCompile Include="..\..\src\setup_wizards.cpp" />
     <ClCompile Include="..\..\src\show_ui.cpp" />

--- a/build-win/CalChart/CalChart.vcxproj.filters
+++ b/build-win/CalChart/CalChart.vcxproj.filters
@@ -19,8 +19,6 @@
     <ClCompile Include="..\..\src\field_canvas.cpp" />
     <ClCompile Include="..\..\src\field_frame.cpp" />
     <ClCompile Include="..\..\src\field_view.cpp" />
-    <ClCompile Include="..\..\src\modes.cpp" />
-    <ClCompile Include="..\..\src\print_ps.cpp" />
     <ClCompile Include="..\..\src\print_ps_dialog.cpp" />
     <ClCompile Include="..\..\src\setup_wizards.cpp" />
     <ClCompile Include="..\..\src\show_ui.cpp" />
@@ -66,6 +64,12 @@
     <ClCompile Include="..\..\src\single_instance_ipc.cpp" />
     <ClCompile Include="..\..\src\ghost_module.cpp" />
     <ClCompile Include="..\..\src\precomp.cpp" />
+    <ClCompile Include="..\..\src\core\modes.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\core\print_ps.cpp">
+      <Filter>core</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\animation_canvas.h" />
@@ -86,9 +90,7 @@
     <ClInclude Include="..\..\src\field_frame.h" />
     <ClInclude Include="..\..\src\field_view.h" />
     <ClInclude Include="..\..\src\linmath.h" />
-    <ClInclude Include="..\..\src\modes.h" />
     <ClInclude Include="..\..\src\platconf.h" />
-    <ClInclude Include="..\..\src\print_ps.h" />
     <ClInclude Include="..\..\src\print_ps_dialog.h" />
     <ClInclude Include="..\..\src\setup_wizards.h" />
     <ClInclude Include="..\..\src\show_ui.h" />
@@ -143,6 +145,12 @@
     <ClInclude Include="..\..\src\ghost_module.h" />
     <ClInclude Include="..\..\src\draw.h" />
     <ClInclude Include="..\..\src\precomp.h" />
+    <ClInclude Include="..\..\src\core\modes.h">
+      <Filter>core</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\core\print_ps.h">
+      <Filter>core</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\calchart.rc" />

--- a/src/confgr.h
+++ b/src/confgr.h
@@ -29,6 +29,7 @@
 #include <functional>
 #include <map>
 #include <array>
+#include <memory>
 
 // forward declare
 class wxPen;

--- a/src/core/modes.h
+++ b/src/core/modes.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <array>
+#include <memory>
 
 #define SPR_YARD_LEFT 8
 #define SPR_YARD_RIGHT 4

--- a/src/core/print_ps.cpp
+++ b/src/core/print_ps.cpp
@@ -133,7 +133,7 @@ CalcValues(bool PrintLandscape, bool PrintDoCont, double PageWidth, double PageH
 	}
 	real_width = PageWidth * DPI;
 	real_height = PageHeight * DPI;
-	return { width, height, real_width, real_height, field_y };
+	return std::tuple<float, float, float, float, float>(width, height, real_width, real_height, field_y);
 }
 
 static std::tuple<float, float, float, float, float, float, float, float, float, float, float, float, float, float, short>
@@ -258,7 +258,8 @@ CalcAllValues(bool PrintLandscape, bool PrintDoCont, bool overview, double PageW
 		width *= fieldwidth/fullwidth;
 		height *= fieldheight/fullheight;
 	}
-	return { width, height, real_width, real_height, field_x, field_y, field_w, field_h, stage_field_x, stage_field_y, stage_field_w, stage_field_h, step_size, spr_step_size, step_width };
+	return std::tuple<float, float, float, float, float, float, float, float, float, float, float, float, float, float, short>(
+		width, height, real_width, real_height, field_x, field_y, field_w, field_h, stage_field_x, stage_field_y, stage_field_w, stage_field_h, step_size, spr_step_size, step_width);
 }
 
 


### PR DESCRIPTION
This branch includes a few minor changes so that everything compiles properly in Visual Studio on Windows. The changes are:
1. The visual studio project files have been updated to understand which files were moved to the core directory so that it can locate them.
2. Files using std::unique_ptr have been modified to #include <memory>
3. Tuple objects are now constructed explicitly (for some reason visual studio doesn't like initializing them with  bracketed lists)