### PR TITLE
Prevent Trivial Error Reports

### DIFF
--- a/src/single_instance_ipc.cpp
+++ b/src/single_instance_ipc.cpp
@@ -192,7 +192,10 @@ void CCAppClient::Disconnect()
 
 bool CCAppClient::Connect(const wxString& host, const wxString& service, const wxString& topic)
 {
+	auto oldLogLevel = wxLog::GetLogLevel();
+	wxLog::SetLogLevel(wxLOG_FatalError); //Make sure that we don't throw errors to the user if the connection fails; we expect connections to fail when we are testing whether or not there is a server, and the user shouldn't be informed when we cannot find a server
 	mConnection = (CCAppClientConnection*)MakeConnection(host, service, topic);
+	wxLog::SetLogLevel(oldLogLevel);
 	return IsConnected();
 }
 


### PR DESCRIPTION
On Windows, CalChart needs to see if there is a host app instance active before it starts up a new fresh instance of the program. Whenever the app failed to find a host app, wxWidgets would report an error, and the user would be notified, though this is actually totally normal behavior for the program. So I disabled that one error.
This is already installed in the windows 3.4.3 release being hosted through sourceforge.