### PR TITLE
Use default values for setting up the field mode.

### DIFF
--- a/src/confgr.cpp
+++ b/src/confgr.cpp
@@ -280,7 +280,7 @@ wxString ShowModeKeys[CalChartConfiguration::kShowModeValues] = { wxT("whash"), 
 template <>
 CalChartConfiguration::ShowModeInfo_t GetConfigValue(const wxString& key, const CalChartConfiguration::ShowModeInfo_t& def)
 {
-	CalChartConfiguration::ShowModeInfo_t values;
+	auto values = def;
 	wxString path = wxT("/SHOWMODES/") + key;
 	for (auto i=0; i < CalChartConfiguration::kShowModeValues; ++i)
 	{
@@ -321,7 +321,7 @@ wxString SpringShowModeKeys[CalChartConfiguration::kSpringShowModeValues] = { wx
 template <>
 CalChartConfiguration::SpringShowModeInfo_t GetConfigValue(const wxString& key, const CalChartConfiguration::SpringShowModeInfo_t& def)
 {
-	CalChartConfiguration::SpringShowModeInfo_t values;
+	auto values = def;
 	wxString path = wxT("/SPRINGSHOWMODES/") + key;
 	for (auto i=0; i < CalChartConfiguration::kSpringShowModeValues; ++i)
 	{


### PR DESCRIPTION
This addresses issue #152  (and probably #141)

I'll check on windows if this fixed it, then merge this soon, then release a 3.4.3a tag to get it out the door