### PR TITLE
Fix For Compilation on Windows

### DIFF
--- a/src/core/math_utils.cpp
+++ b/src/core/math_utils.cpp
@@ -26,7 +26,7 @@
 
 #include <ctype.h>
 #include <list>
-
+#include <tuple>
 
 float BoundDirection(float f)
 {


### PR DESCRIPTION
Needed to explicitly add the `tuple` type via an include for `math_utils.cpp`