### PR TITLE
Fix for #252: Rotate Tool Snaps To Grid, Causing Strange Effects

### DIFF
--- a/src/core/cc_sheet.cpp
+++ b/src/core/cc_sheet.cpp
@@ -741,14 +741,14 @@ using namespace Parser;
 void Sheet::sheet_round_trip_test()
 {
     {
-        auto blank_sheet = Sheet::Sheet(0);
+        auto blank_sheet = Sheet(0);
         auto blank_sheet_data = blank_sheet.SerializeSheet();
         // need to pull out the sheet data
         auto table = Parser::ParseOutLabels(blank_sheet_data.data(),
             blank_sheet_data.data() + blank_sheet_data.size());
         assert(table.size() == 1);
         assert(std::get<0>(table.front()) == INGL_SHET);
-        auto re_read_sheet = Sheet::Sheet(0, std::get<1>(table.front()),
+        auto re_read_sheet = Sheet(0, std::get<1>(table.front()),
             std::get<2>(table.front()),
             Current_version_and_later());
         auto re_read_sheet_data = re_read_sheet.SerializeSheet();
@@ -756,14 +756,14 @@ void Sheet::sheet_round_trip_test()
         assert(is_equal);
     }
     {
-        auto blank_sheet = Sheet::Sheet(0, "new_sheet");
+        auto blank_sheet = Sheet(0, "new_sheet");
         auto blank_sheet_data = blank_sheet.SerializeSheet();
         // need to pull out the sheet data
         auto table = Parser::ParseOutLabels(blank_sheet_data.data(),
             blank_sheet_data.data() + blank_sheet_data.size());
         assert(table.size() == 1);
         assert(std::get<0>(table.front()) == INGL_SHET);
-        auto re_read_sheet = Sheet::Sheet(0, std::get<1>(table.front()),
+        auto re_read_sheet = Sheet(0, std::get<1>(table.front()),
             std::get<2>(table.front()),
             Current_version_and_later());
         auto re_read_sheet_data = re_read_sheet.SerializeSheet();
@@ -771,7 +771,7 @@ void Sheet::sheet_round_trip_test()
         assert(is_equal);
     }
     {
-        auto blank_sheet = Sheet::Sheet(1, "new_sheet");
+        auto blank_sheet = Sheet(1, "new_sheet");
         blank_sheet.SetName("new_name");
         blank_sheet.SetPosition(Coord(10, 10), 0);
         blank_sheet.SetPosition(Coord(20, 10), 0, 1);
@@ -788,7 +788,7 @@ void Sheet::sheet_round_trip_test()
             blank_sheet_data.data() + blank_sheet_data.size());
         assert(table.size() == 1);
         assert(std::get<0>(table.front()) == INGL_SHET);
-        auto re_read_sheet = Sheet::Sheet(1, std::get<1>(table.front()),
+        auto re_read_sheet = Sheet(1, std::get<1>(table.front()),
             std::get<2>(table.front()),
             Current_version_and_later());
         auto re_read_sheet_data = re_read_sheet.SerializeSheet();

--- a/src/field_canvas.cpp
+++ b/src/field_canvas.cpp
@@ -441,7 +441,7 @@ void FieldCanvas::MoveDrag(const CalChart::Coord& end)
         if (m_move_points->IsReadyForMoving()) {
             mMovePoints = m_move_points->TransformPoints(selected_points);
             for (auto& i : mMovePoints) {
-                i.second = mView.ClipPositionToShowMode(SnapToGrid(i.second));
+                i.second = mView.ClipPositionToShowMode(i.second);
             }
         }
     }


### PR DESCRIPTION
In the new movement tool system, `SnapToGrid` is called to:

1) Snap the mouse position to the grid, before the mouse position is fed to the tool
2) Snap the final positions of the marchers to the grid, after the tool has moved them

I think (1) is sufficient for a good experience. By snapping the mouse position to the grid, standard tools like 'Translate Points' can still be used to move marchers around the grid without a fuss. By removing (2), I think we improve the experience of tools like 'Rotate Points' and 'Shape Points into Line'. If (2) is enabled, then 'Rotate Points' has the effect mentioned in #252 , and 'Shape Points into Line' can create lines that are not evenly-spaced (because even-spacing would put marchers off-the-grid).