### PR TITLE
Fix for #267: copy/pasting stuntsheets doesn't work (Windows)

### DIFF
--- a/src/field_frame.cpp
+++ b/src/field_frame.cpp
@@ -552,7 +552,7 @@ void FieldFrame::OnCmdPasteSheet(wxCommandEvent& event)
             wxCustomDataObject clipboardObject(kSheetDataClipboardFormat);
             wxTheClipboard->GetData(clipboardObject);
 
-            uint16_t numPoints;
+            auto numPoints = GetShow()->GetNumPoints();
             memcpy(&numPoints, clipboardObject.GetData(), sizeof(numPoints));
             if (numPoints != GetShow()->GetNumPoints()) {
                 wxMessageBox(wxString::Format(


### PR DESCRIPTION
Addressing #267 