### PR TITLE
Unreliable Viewer File Generation

### DIFF
--- a/src/core/animate.cpp
+++ b/src/core/animate.cpp
@@ -93,13 +93,19 @@ Animation::Animation(const Show& show, NotifyStatus notifyStatus, NotifyErrorLis
     // the variables are persistant through the entire compile process.
     AnimationVariables variablesStates;
 
-    int sheetIndex = 0;
+    int newSheetIndex = 0;
+    int prevSheetIndex = 0;
     for (auto curr_sheet = show.GetSheetBegin(); curr_sheet != show.GetSheetEnd(); ++curr_sheet) {
-        mAnimSheetIndices.push_back(sheetIndex);
+        
         if (!curr_sheet->IsInAnimation())
+        {
+            mAnimSheetIndices.push_back(prevSheetIndex);
             continue;
+        }
 
-        sheetIndex++;
+        mAnimSheetIndices.push_back(newSheetIndex);
+        prevSheetIndex = newSheetIndex;
+        newSheetIndex++;
 
         // Now parse continuity
         AnimationErrors errors;

--- a/src/core/cc_show.cpp
+++ b/src/core/cc_show.cpp
@@ -518,11 +518,17 @@ void Show::toOnlineViewerJSON(JSONElement& dest, const Animation& compiledShow) 
 
     // Fill in 'sheets' with the JSON representation of each sheet
     JSONDataArrayAccessor sheetsAccessor = showObjectAccessor["sheets"];
-    unsigned i = 0;
+    unsigned sheetIndex = 0;
     auto animateSheetIter = compiledShow.sheetsBegin();
-    for (auto iter = GetSheetBegin(); iter != GetSheetEnd(); iter++, i++, animateSheetIter++) {
-        sheetsAccessor->pushBack(JSONElement::makeNull());
-        (*iter).toOnlineViewerJSON(sheetsAccessor[i], i + 1, mPtLabels, *animateSheetIter);
+    auto showSheetIter = GetSheetBegin();
+    while (showSheetIter != GetSheetEnd()) {
+        if (showSheetIter->IsInAnimation()) {
+            sheetsAccessor->pushBack(JSONElement::makeNull());
+            showSheetIter->toOnlineViewerJSON(sheetsAccessor[sheetIndex], sheetIndex + 1, mPtLabels, *animateSheetIter);
+            animateSheetIter++;
+        }
+        sheetIndex++;
+        showSheetIter++;
     }
 }
 

--- a/src/core/json_grammar.h
+++ b/src/core/json_grammar.h
@@ -8,6 +8,7 @@
 #include <boost/spirit/include/karma.hpp>
 #include <boost/spirit/include/karma_string.hpp>
 #include <boost/spirit/include/phoenix.hpp>
+#include <boost/spirit/include/support_auto.hpp>
 
 #include "json.h"
 
@@ -44,12 +45,12 @@ struct JSONExportGrammar
         : JSONExportGrammar::base_type(mainObject)
     {
         indentationLevel = 0;
-        std::string indentation_string = "    ";
-        auto indentationLevelRef = phoenix::ref(indentationLevel);
-        auto increaseIndent = karma::eps[++indentationLevelRef];
-        auto decreaseIndent = karma::eps[--indentationLevelRef];
-        auto indent = karma::repeat(indentationLevelRef)[karma::lit(indentation_string)];
-        auto begin_newline = karma::eol << indent;
+        static const std::string indentation_string = "    ";
+        auto indentationLevelRef = boost::proto::deep_copy(phoenix::ref(indentationLevel));
+        auto increaseIndent = boost::proto::deep_copy(karma::eps[++indentationLevelRef]);
+        auto decreaseIndent = boost::proto::deep_copy(karma::eps[--indentationLevelRef]);
+        auto indent = boost::proto::deep_copy(karma::repeat(indentationLevelRef)[karma::lit(indentation_string)]);
+        auto begin_newline = boost::proto::deep_copy(karma::eol << indent);
 
         // Rules that will succeed only if the JSONElement is of a particular type
         isNumber = checkType(JSONData::JSONDataTypeNumber);
@@ -128,9 +129,9 @@ struct JSONExportGrammar
     karma::rule<OutputIterator> null;
     karma::rule<OutputIterator, const JSONElement&()> block_element;
     karma::rule<OutputIterator, karma::locals<const JSONDataObject*>, JSONDataObjectConstAccessor()> object;
-    karma::rule<OutputIterator, std::vector<std::pair<const std::string&, const JSONElement&>>&()> objectContent;
+    karma::rule<OutputIterator, std::vector<std::pair<const std::string&, const JSONElement&>>()> objectContent;
     karma::rule<OutputIterator, std::pair<const std::string&, const JSONElement&>&()> keyValPair;
     karma::rule<OutputIterator, karma::locals<const JSONDataArray*>, JSONDataArrayConstAccessor()> array;
-    karma::rule<OutputIterator, std::vector<std::reference_wrapper<const JSONElement>>&()> arrayContent;
+    karma::rule<OutputIterator, std::vector<std::reference_wrapper<const JSONElement>>()> arrayContent;
 };
 }


### PR DESCRIPTION
#271

There are two separate fixes here:
1) Stuntsheets with zero beats don't appear in the animation. When generating JSON output, we cross-reference stunt sheets against their animated counterparts in order to access the compiled movements of each marcher. In order to cross-reference accurately, we need to take account of whether or not stuntsheets actually appear in the animation.
2) The JSON grammar was crashing when compiler optimization was applied. I removed use of `auto` because it is unsafe when dealing with Spirit grammar expressions, and also removed inappropriate references from several grammar rules.