### PR TITLE
fix #289 Crash when clicking the space below the Field thumbnail

### DIFF
--- a/src/FieldThumbnailBrowser.cpp
+++ b/src/FieldThumbnailBrowser.cpp
@@ -206,5 +206,5 @@ void FieldThumbnailBrowser::HandleKey(wxKeyEvent& event)
 void FieldThumbnailBrowser::HandleMouseDown(wxMouseEvent& event)
 {
     auto which = WhichCell(CalcUnscrolledPosition(event.GetPosition()));
-    mDoc->SetCurrentSheet(which);
+    mDoc->SetCurrentSheet(std::min(which, mDoc->GetNumSheets() - 1));
 }


### PR DESCRIPTION
Don't read off the end of an array