### PR TITLE
Improving click and drag by not unselecting groups.

### DIFF
--- a/src/FieldCanvas.cpp
+++ b/src/FieldCanvas.cpp
@@ -147,10 +147,10 @@ void FieldCanvas::OnMouseLeftDown_default(CalChart::Coord pos, bool shiftDown, b
     if (curr_lasso == CC_DRAG::SWAP) {
         OnMouseLeftDown_CC_DRAG_SWAP(pos);
     }
-    if (!(shiftDown || altDown)) {
+    auto i = mView->FindPoint(pos);
+    if ((i < 0) && !(shiftDown || altDown)) {
         mView->UnselectAll();
     }
-    auto i = mView->FindPoint(pos);
     if (i < 0) {
         // if no point selected, we grab using the current lasso
         BeginSelectDrag(curr_lasso, pos);


### PR DESCRIPTION
I've been trying out an alternative approach where click and drag on a member of a group does not unselect the other members of the group.  This feels much better.