### PR TITLE
removing boost dependency from calchart.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,6 @@ configure_file (
 # calchart_cmd: CLI for parsing files and testing
 # CalChart: The App itself
 
-# CalChart requires Boost.  Find it and include the directories here.
-find_package (Boost 1.60 REQUIRED)
-
 # CalChart requires BISON/FLEX for the grammar
 find_package (BISON REQUIRED)
 find_package (FLEX REQUIRED)
@@ -140,7 +137,6 @@ target_include_directories (
   calchart_core
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src/core
-  ${Boost_INCLUDE_DIRS}
   ${PROJECT_BINARY_DIR}/version
   ${CMAKE_CURRENT_SOURCE_DIR}/submodules/munkres-cpp/src
   )
@@ -176,7 +172,6 @@ target_include_directories (
   PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/src/core"
   "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  "${Boost_INCLUDE_DIRS}"
   "${PROJECT_BINARY_DIR}/version"
   )
 
@@ -321,14 +316,13 @@ set_target_properties (
   "${AllResources}"
   )
 
-target_link_libraries (CalChart calchart_core ${Boost_LIBRARIES})
+target_link_libraries (CalChart calchart_core)
 target_link_libraries (CalChart nlohmann_json::nlohmann_json)
 
 #target_link_libraries (
 #  CalChart
 #  PRIVATE
 #  calchart_core
-#  ${Boost_LIBRARIES}
 #  nlohmann_json::nlohmann_json
 #  )
 
@@ -353,7 +347,6 @@ target_include_directories (
   "${CMAKE_CURRENT_SOURCE_DIR}/src"
   "${CMAKE_CURRENT_SOURCE_DIR}/resources"
   "${CMAKE_CURRENT_SOURCE_DIR}/submodules/munkres-cpp/src"
-  "${Boost_INCLUDE_DIRS}"
   "${PROJECT_BINARY_DIR}/version"
   )
 

--- a/README-MACOSX.md
+++ b/README-MACOSX.md
@@ -27,12 +27,6 @@ https://trac.macports.org/ticket/58450
 
 $ brew install cmake
 
-### Boost
-
-CalChart uses Boost.  See boost.org for more information about what Boost is.  You will need to make sure it is installed on your system somewhere common so CMake can find it.  I recommend using brew to install it.  See https://brew.sh.
-
-$ brew install boost
-
 ## Building CalChart:
 
 CalChart uses cmake to configure and run the platform specific build system.  For Mac we use Xcode.

--- a/README-WINDOWS.md
+++ b/README-WINDOWS.md
@@ -18,25 +18,11 @@ We tried Visual Studio Community 2017.
 You'll need to install the "Visual C++" "Common Tools for Visual C++ 2017".
 
 
-## Download Boost
-Visit http://www.boost.org/ and download the latest version of Boost. 
-Place the downloaded Boost directory somewhere on your computer:
-
-	e.g. c:\boost
-
-Remember where you place this Boost directory. In the next section, I will refer to the directory as $YOUR_BOOST_DIRECTORY. In the example above, $YOUR_BOOST_DIRECTORY = `c:\boost`
-
 ## Add environment variables
 Go to Control Panel->System->Advanced System Settings->Environment Variables
 Add the following User variables:
 
-	BOOST_DIR=$YOUR_BOOST_DIRECTORY
-	BOOST_ROOT=$YOUR_BOOST_DIRECTORY
-	Boost_INCLUDE_DIR=$YOUR_BOOST_DIRECTORY
 	CMAKE_PREFIX_PATH=$PATH_TO_BISON
-
-(see the `Download Boost` section above for the meaning of $YOUR_BOOST_DIRECTORY)
-
 
 ## Get CMake
 Read instructions at 

--- a/src/core/CalChartShowMode.h
+++ b/src/core/CalChartShowMode.h
@@ -29,9 +29,6 @@
 #include <string>
 #include <vector>
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/array.hpp>
-
 namespace CalChart {
 
 static constexpr auto SPR_YARD_LEFT = 8;
@@ -114,18 +111,6 @@ private:
 
     YardLinesInfo_t mYardLines;
 
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int /*version*/)
-    {
-        ar& mSize;
-        ar& mOffset;
-        ar& mBorder1;
-        ar& mBorder2;
-        ar& mHashW;
-        ar& mHashE;
-        ar& mYardLines;
-    }
     friend bool operator==(ShowMode const& lhs, ShowMode const& rhs);
 };
 


### PR DESCRIPTION
Looks like boost is not really needed and can be removed as a dependency.