### PR TITLE
Dev/improve math

### DIFF
--- a/src/AnimationView.cpp
+++ b/src/AnimationView.cpp
@@ -103,7 +103,7 @@ void AnimationView::OnDrawDots(wxDC& dc, CalChartConfiguration const& config)
                 wxCalChart::setBrushAndPen(dc, config.Get_CalChartBrushAndPen(CalChart::Colors::POINT_ANIM_COLLISION));
             }
         } else if (mView->IsSelected(info.index)) {
-            switch (AngleToDirection(info.mFacingDirection)) {
+            switch (CalChart::AngleToDirection(info.mFacingDirection)) {
             case CalChart::Direction::SouthWest:
             case CalChart::Direction::West:
             case CalChart::Direction::NorthWest: {
@@ -119,7 +119,7 @@ void AnimationView::OnDrawDots(wxDC& dc, CalChartConfiguration const& config)
             }
             }
         } else {
-            switch (AngleToDirection(info.mFacingDirection)) {
+            switch (CalChart::AngleToDirection(info.mFacingDirection)) {
             case CalChart::Direction::SouthWest:
             case CalChart::Direction::West:
             case CalChart::Direction::NorthWest: {
@@ -154,7 +154,7 @@ void AnimationView::OnDrawSprites(wxDC& dc, CalChartConfiguration const& config)
     for (auto info : mAnimation->GetAllAnimateInfo()) {
         auto image_offset = !GetAnimationFrame()->TimerOn() ? 0 : OnBeat() ? 1
                                                                            : 2;
-        auto image_index = AngleToQuadrant(info.mFacingDirection) + image_offset * 8;
+        auto image_index = CalChart::AngleToQuadrant(info.mFacingDirection) + image_offset * 8;
         auto image = mSpriteImages[image_index];
         image = image.Scale(image.GetWidth() * scale, image.GetHeight() * scale);
         if (mView->IsSelected(info.index)) {
@@ -316,7 +316,7 @@ AnimationView::MarcherInfo AnimationView::GetMarcherInfo(int which) const
     MarcherInfo info{};
     if (mAnimation) {
         auto anim_info = mAnimation->GetAnimateInfo(which);
-        info.direction = NormalizeAngleRad((anim_info.mFacingDirection * M_PI / 180.0));
+        info.direction = CalChart::NormalizeAngleRad(CalChart::Deg2Rad(anim_info.mFacingDirection));
 
         auto position = anim_info.mPosition;
         info.x = CalChart::CoordUnits2Float(position.x);

--- a/src/CCOmniviewCanvas.cpp
+++ b/src/CCOmniviewCanvas.cpp
@@ -274,59 +274,59 @@ auto GetMarcherTextureAndPoints(float cameraAngleToMarcher, float marcherDirecti
 {
     // Returns which direction they are facing in regards to the camera.
     float relativeAngle = marcherDirection - cameraAngleToMarcher; // convert to relative angle;
-    relativeAngle = NormalizeAngleRad(relativeAngle);
+    relativeAngle = CalChart::NormalizeAngleRad(relativeAngle);
 
-    if (cameraAngleToMarcher >= 1.0 * M_PI / 8.0 && cameraAngleToMarcher < 3.0 * M_PI / 8.0) {
+    if (cameraAngleToMarcher >= 1.0 * std::numbers::pi / 8.0 && cameraAngleToMarcher < 3.0 * std::numbers::pi / 8.0) {
         y1 += 0.45f;
         y2 -= 0.45f;
         x1 -= 0.45f;
         x2 += 0.45f;
-    } else if (cameraAngleToMarcher >= 3.0 * M_PI / 8.0 && cameraAngleToMarcher < 5.0 * M_PI / 8.0) {
+    } else if (cameraAngleToMarcher >= 3.0 * std::numbers::pi / 8.0 && cameraAngleToMarcher < 5.0 * std::numbers::pi / 8.0) {
         x1 -= 0.45f;
         x2 += 0.45f;
-    } else if (cameraAngleToMarcher >= 5.0 * M_PI / 8.0 && cameraAngleToMarcher < 7.0 * M_PI / 8.0) {
+    } else if (cameraAngleToMarcher >= 5.0 * std::numbers::pi / 8.0 && cameraAngleToMarcher < 7.0 * std::numbers::pi / 8.0) {
         y1 -= 0.45f;
         y2 += 0.45f;
         x1 -= 0.45f;
         x2 += 0.45f;
-    } else if (cameraAngleToMarcher >= 7.0 * M_PI / 8.0 && cameraAngleToMarcher < 9.0 * M_PI / 8.0) {
+    } else if (cameraAngleToMarcher >= 7.0 * std::numbers::pi / 8.0 && cameraAngleToMarcher < 9.0 * std::numbers::pi / 8.0) {
         y1 -= 0.45f;
         y2 += 0.45f;
-    } else if (cameraAngleToMarcher >= 9.0 * M_PI / 8.0 && cameraAngleToMarcher < 11.0 * M_PI / 8.0) {
+    } else if (cameraAngleToMarcher >= 9.0 * std::numbers::pi / 8.0 && cameraAngleToMarcher < 11.0 * std::numbers::pi / 8.0) {
         y1 -= 0.45f;
         y2 += 0.45f;
         x1 += 0.45f;
         x2 -= 0.45f;
-    } else if (cameraAngleToMarcher >= 11.0 * M_PI / 8.0 && cameraAngleToMarcher < 13.0 * M_PI / 8.0) {
+    } else if (cameraAngleToMarcher >= 11.0 * std::numbers::pi / 8.0 && cameraAngleToMarcher < 13.0 * std::numbers::pi / 8.0) {
         x1 += 0.45f;
         x2 -= 0.45f;
-    } else if (cameraAngleToMarcher >= 13.0 * M_PI / 8.0 && relativeAngle < 15.0 * M_PI / 8.0) {
+    } else if (cameraAngleToMarcher >= 13.0 * std::numbers::pi / 8.0 && relativeAngle < 15.0 * std::numbers::pi / 8.0) {
         y1 += 0.45f;
         y2 -= 0.45f;
         x1 += 0.45f;
         x2 -= 0.45f;
-    } else // if (cameraAngleToMarcher >= 15.0*M_PI/8.0 || cameraAngleToMarcher <
-    // 1.0*M_PI/8.0) // and everything else
+    } else // if (cameraAngleToMarcher >= 15.0*std::numbers::pi/8.0 || cameraAngleToMarcher <
+    // 1.0*std::numbers::pi/8.0) // and everything else
     {
         y1 += 0.45f;
         y2 -= 0.45f;
     }
 
-    if (relativeAngle >= 1.0 * M_PI / 8.0 && relativeAngle < 3.0 * M_PI / 8.0) {
+    if (relativeAngle >= 1.0 * std::numbers::pi / 8.0 && relativeAngle < 3.0 * std::numbers::pi / 8.0) {
         return WhichImage::kBR0;
-    } else if (relativeAngle >= 3.0 * M_PI / 8.0 && relativeAngle < 5.0 * M_PI / 8.0) {
+    } else if (relativeAngle >= 3.0 * std::numbers::pi / 8.0 && relativeAngle < 5.0 * std::numbers::pi / 8.0) {
         return WhichImage::kR0;
-    } else if (relativeAngle >= 5.0 * M_PI / 8.0 && relativeAngle < 7.0 * M_PI / 8.0) {
+    } else if (relativeAngle >= 5.0 * std::numbers::pi / 8.0 && relativeAngle < 7.0 * std::numbers::pi / 8.0) {
         return WhichImage::kFR0;
-    } else if (relativeAngle >= 7.0 * M_PI / 8.0 && relativeAngle < 9.0 * M_PI / 8.0) {
+    } else if (relativeAngle >= 7.0 * std::numbers::pi / 8.0 && relativeAngle < 9.0 * std::numbers::pi / 8.0) {
         return WhichImage::kF0;
-    } else if (relativeAngle >= 9.0 * M_PI / 8.0 && relativeAngle < 11.0 * M_PI / 8.0) {
+    } else if (relativeAngle >= 9.0 * std::numbers::pi / 8.0 && relativeAngle < 11.0 * std::numbers::pi / 8.0) {
         return WhichImage::kFL0;
-    } else if (relativeAngle >= 11.0 * M_PI / 8.0 && relativeAngle < 13.0 * M_PI / 8.0) {
+    } else if (relativeAngle >= 11.0 * std::numbers::pi / 8.0 && relativeAngle < 13.0 * std::numbers::pi / 8.0) {
         return WhichImage::kL0;
-    } else if (relativeAngle >= 13.0 * M_PI / 8.0 && relativeAngle < 15.0 * M_PI / 8.0) {
+    } else if (relativeAngle >= 13.0 * std::numbers::pi / 8.0 && relativeAngle < 15.0 * std::numbers::pi / 8.0) {
         return WhichImage::kBL0;
-    } else // if (relativeAngle >= 15.0*M_PI/8.0 || relativeAngle < 1.0*M_PI/8.0)
+    } else // if (relativeAngle >= 15.0*std::numbers::pi/8.0 || relativeAngle < 1.0*std::numbers::pi/8.0)
     // // and everything else
     {
         return WhichImage::kB0;
@@ -533,7 +533,7 @@ void CCOmniView_GLContext::DrawField(float FieldEW, float FieldNS, bool crowdOn)
 
 void CCOmniView_GLContext::Draw3dMarcher(AnimationView::MarcherInfo const& info, CCOmniviewCanvas::ViewPoint const& viewpoint, WhichMarchingStyle style)
 {
-    auto ang = NormalizeAngleRad(GetAngle(info.x, info.y, viewpoint));
+    auto ang = CalChart::NormalizeAngleRad(GetAngle(info.x, info.y, viewpoint));
     auto dir = info.direction;
 
     auto x2 = info.x;
@@ -601,7 +601,7 @@ void CCOmniviewCanvas::SetView(AnimationView* view)
 // http://nehe.gamedev.net/article/replacement_for_gluperspective/21002/
 static void myGLUPerspective(GLdouble fovY, GLdouble aspect, GLdouble zNear, GLdouble zFar)
 {
-    auto fH = tan(fovY / 360.0 * M_PI) * zNear;
+    auto fH = tan(fovY / 360.0 * std::numbers::pi) * zNear;
     auto fW = fH * aspect;
     glFrustum(-fW, fW, -fH, fH, zNear, zFar);
 }
@@ -688,8 +688,8 @@ void CCOmniviewCanvas::OnPaint(wxPaintEvent&)
     glViewport(0, 0, ClientSize.x, ClientSize.y);
 
     CalChart::Coord fieldSize = mView ? mView->GetShowMode().FieldSize() : CalChart::Coord(160, 80);
-    float FieldEW = CalChart::CoordUnits2Float(fieldSize.y);
-    float FieldNS = CalChart::CoordUnits2Float(fieldSize.x);
+    auto FieldEW = CalChart::CoordUnits2Float(fieldSize.y);
+    auto FieldNS = CalChart::CoordUnits2Float(fieldSize.x);
 
     glClear(GL_COLOR_BUFFER_BIT);
     // set our view point:
@@ -736,7 +736,7 @@ void CCOmniviewCanvas::OnChar(wxKeyEvent& event)
         if (event.GetKeyCode() == '!') {
             mViewPoint.y *= -1;
             mViewPoint.x *= -1;
-            mViewAngle = NormalizeAngleRad(mViewAngle + M_PI);
+            mViewAngle = CalChart::NormalizeAngleRad(mViewAngle + std::numbers::pi);
         }
         break;
     case '2':
@@ -748,7 +748,7 @@ void CCOmniviewCanvas::OnChar(wxKeyEvent& event)
         if (event.GetKeyCode() == '@') {
             mViewPoint.y *= -1;
             mViewPoint.x *= -1;
-            mViewAngle = NormalizeAngleRad(mViewAngle + M_PI);
+            mViewAngle = CalChart::NormalizeAngleRad(mViewAngle + std::numbers::pi);
         }
         break;
     case '3':
@@ -760,7 +760,7 @@ void CCOmniviewCanvas::OnChar(wxKeyEvent& event)
         if (event.GetKeyCode() == '#') {
             mViewPoint.y *= -1;
             mViewPoint.x *= -1;
-            mViewAngle = NormalizeAngleRad(mViewAngle + M_PI);
+            mViewAngle = CalChart::NormalizeAngleRad(mViewAngle + std::numbers::pi);
         }
         break;
 
@@ -833,12 +833,12 @@ void CCOmniviewCanvas::OnChar(wxKeyEvent& event)
     case 'q':
         OnCmd_FollowMarcher(-1);
         mViewAngle += AngleStepIncr;
-        mViewAngle = NormalizeAngleRad(mViewAngle);
+        mViewAngle = CalChart::NormalizeAngleRad(mViewAngle);
         break;
     case 'e':
         OnCmd_FollowMarcher(-1);
         mViewAngle -= AngleStepIncr;
-        mViewAngle = NormalizeAngleRad(mViewAngle);
+        mViewAngle = CalChart::NormalizeAngleRad(mViewAngle);
         break;
     case 'r':
         OnCmd_FollowMarcher(-1);
@@ -865,13 +865,13 @@ void CCOmniviewCanvas::OnChar(wxKeyEvent& event)
     // move, following the FPS model
     case 'a':
         OnCmd_FollowMarcher(-1);
-        mViewPoint.x += -stepIncr * cos(mViewAngle - M_PI / 2);
-        mViewPoint.y += -stepIncr * sin(mViewAngle - M_PI / 2);
+        mViewPoint.x += -stepIncr * cos(mViewAngle - std::numbers::pi / 2);
+        mViewPoint.y += -stepIncr * sin(mViewAngle - std::numbers::pi / 2);
         break;
     case 'd':
         OnCmd_FollowMarcher(-1);
-        mViewPoint.x += stepIncr * cos(mViewAngle - M_PI / 2);
-        mViewPoint.y += stepIncr * sin(mViewAngle - M_PI / 2);
+        mViewPoint.x += stepIncr * cos(mViewAngle - std::numbers::pi / 2);
+        mViewPoint.y += stepIncr * sin(mViewAngle - std::numbers::pi / 2);
         break;
     case 's':
         OnCmd_FollowMarcher(-1);

--- a/src/CalChartConfiguration.cpp
+++ b/src/CalChartConfiguration.cpp
@@ -31,13 +31,11 @@
 #include "CalChartShowMode.h"
 #include "cc_omniview_constants.h"
 
-using namespace CalChart;
-
 // Yard lines
-const std::array<std::string, kYardTextValues> yard_text_defaults = []() {
-    std::array<std::string, kYardTextValues> values;
-    auto default_yards = ShowMode::GetDefaultYardLines();
-    for (auto i = 0; i < kYardTextValues; ++i) {
+const std::array<std::string, CalChart::kYardTextValues> yard_text_defaults = []() {
+    std::array<std::string, CalChart::kYardTextValues> values;
+    auto default_yards = CalChart::ShowMode::GetDefaultYardLines();
+    for (auto i = 0; i < CalChart::kYardTextValues; ++i) {
         values[i] = default_yards[i];
     }
     return values;
@@ -45,21 +43,21 @@ const std::array<std::string, kYardTextValues> yard_text_defaults = []() {
 
 const auto yard_text_index = yard_text_defaults;
 
-const std::string kPaletteColorDefault[kNumberPalettes] = {
+const std::array<std::string, kNumberPalettes> kPaletteColorDefault = {
     "FOREST GREEN",
     "GREY",
     "GREY",
     "GREY",
 };
 
-const std::string kPaletteNameDefault[kNumberPalettes] = {
+const std::array<std::string, kNumberPalettes> kPaletteNameDefault = {
     "Default",
     "[Unset]",
     "[Unset]",
     "[Unset]",
 };
 
-static CalChartConfiguration& GetConfig()
+static auto GetConfig() -> CalChartConfiguration&
 {
     static CalChartConfiguration sconfig;
     return sconfig;
@@ -215,7 +213,7 @@ GetConfigValue(const std::string& key,
     auto values = def;
     std::string path = "/SHOWMODES/" + key;
     for (auto i = 0; i < CalChart::kShowModeValues; ++i) {
-        values[i] = GetConfigPathKey<long>(path, ShowModeKeys[i], values[i]);
+        values[i] = GetConfigPathKey<long>(path, CalChart::ShowModeKeys[i], values[i]);
     }
     return values;
 }
@@ -223,11 +221,11 @@ GetConfigValue(const std::string& key,
 // Specialize on show mode
 template <>
 void SetConfigValue(const std::string& key,
-    const ShowModeData_t& value,
-    const ShowModeData_t& def)
+    const CalChart::ShowModeData_t& value,
+    const CalChart::ShowModeData_t& def)
 {
     // don't write if we don't have to
-    if (GetConfigValue<ShowModeData_t>(key, def) == value) {
+    if (GetConfigValue<CalChart::ShowModeData_t>(key, def) == value) {
         return;
     }
     std::string path = "/SHOWMODES/" + key;
@@ -236,13 +234,13 @@ void SetConfigValue(const std::string& key,
     // clear out the value if it's the same as the default
     if (def == value) {
         for (auto i = 0; i < CalChart::kShowModeValues; ++i) {
-            ClearConfigPathKey<long>(path, ShowModeKeys[i]);
+            ClearConfigPathKey<long>(path, CalChart::ShowModeKeys[i]);
         }
         return;
     }
 
     for (auto i = 0; i < CalChart::kShowModeValues; ++i) {
-        SetConfigPathKey<long>(path, ShowModeKeys[i], value[i]);
+        SetConfigPathKey<long>(path, CalChart::ShowModeKeys[i], value[i]);
     }
 }
 
@@ -379,7 +377,7 @@ IMPLEMENT_CONFIGURATION_FUNCTIONS(ContCellRounding, long, 4);
 IMPLEMENT_CONFIGURATION_FUNCTIONS(ContCellTextPadding, long, 4);
 IMPLEMENT_CONFIGURATION_FUNCTIONS(ContCellBoxPadding, long, 4);
 
-// OBSOLETE Settigns
+// OBSOLETE Settings
 // "MainFrameZoom" now obsolete with version post 3.2, use "MainFrameZoom2"
 // IMPLEMENT_CONFIGURATION_FUNCTIONS( MainFrameZoom, float, 0.5);
 // "MainFrameZoom", "MainFrameWidth", "MainFrameHeight" now obsolete with
@@ -391,38 +389,38 @@ IMPLEMENT_CONFIGURATION_FUNCTIONS(ContCellBoxPadding, long, 4);
 template <int Which, typename T, std::size_t N, typename Indices = std::make_index_sequence<N>>
 auto GetVectorFromTupleArray(std::array<T, N> const& a)
 {
-    auto data = details::at_offset<Which>(a, Indices{});
+    auto data = CalChart::details::at_offset<Which>(a, Indices{});
     return std::vector(data.begin(), data.end());
 }
 
 std::vector<std::string> CalChartConfiguration::GetColorNames() const
 {
-    return GetVectorFromTupleArray<0>(ColorInfoDefaults);
+    return GetVectorFromTupleArray<0>(CalChart::ColorInfoDefaults);
 }
 
 std::vector<std::string> CalChartConfiguration::GetDefaultColors() const
 {
-    return GetVectorFromTupleArray<1>(ColorInfoDefaults);
+    return GetVectorFromTupleArray<1>(CalChart::ColorInfoDefaults);
 }
 
 std::vector<int> CalChartConfiguration::GetDefaultPenWidth() const
 {
-    return GetVectorFromTupleArray<2>(ColorInfoDefaults);
+    return GetVectorFromTupleArray<2>(CalChart::ColorInfoDefaults);
 }
 
 std::vector<std::string> CalChartConfiguration::GetContCellColorNames() const
 {
-    return GetVectorFromTupleArray<0>(ContCellColorInfoDefaults);
+    return GetVectorFromTupleArray<0>(CalChart::ContCellColorInfoDefaults);
 }
 
 std::vector<std::string> CalChartConfiguration::GetContCellDefaultColors() const
 {
-    return GetVectorFromTupleArray<1>(ContCellColorInfoDefaults);
+    return GetVectorFromTupleArray<1>(CalChart::ContCellColorInfoDefaults);
 }
 
 std::vector<int> CalChartConfiguration::GetContCellDefaultPenWidth() const
 {
-    return GetVectorFromTupleArray<2>(ContCellColorInfoDefaults);
+    return GetVectorFromTupleArray<2>(CalChart::ContCellColorInfoDefaults);
 }
 
 std::vector<std::string> CalChartConfiguration::Get_yard_text_index() const
@@ -630,23 +628,23 @@ CalChartConfiguration::Get_ShowModeData(CalChart::ShowModes which) const
     }
 
     if (!mShowModeInfos.count(which)) {
-        auto& defaultValue = kShowModeDefaultValues[twhich];
-        mShowModeInfos[which] = GetConfigValue<ShowModeData_t>(
+        auto& defaultValue = CalChart::kShowModeDefaultValues[twhich];
+        mShowModeInfos[which] = GetConfigValue<CalChart::ShowModeData_t>(
             std::string(std::get<0>(defaultValue)), CalChart::ShowModeData_t{ std::get<1>(defaultValue) });
     }
     return mShowModeInfos[which];
 }
 
-void CalChartConfiguration::Set_ShowModeData(CalChart::ShowModes which, ShowModeData_t const& values)
+void CalChartConfiguration::Set_ShowModeData(CalChart::ShowModes which, CalChart::ShowModeData_t const& values)
 {
     auto twhich = toUType(which);
     if (twhich >= toUType(CalChart::ShowModes::NUM)) {
         throw std::runtime_error("Error, exceeding CalChart::ShowModes::NUM size");
     }
 
-    auto& defaultValue = kShowModeDefaultValues[twhich];
+    auto& defaultValue = CalChart::kShowModeDefaultValues[twhich];
     mWriteQueue[std::string(std::get<0>(defaultValue))] = [defaultValue, which, values]() {
-        SetConfigValue<ShowModeData_t>(std::string(std::get<0>(defaultValue)), values,
+        SetConfigValue<CalChart::ShowModeData_t>(std::string(std::get<0>(defaultValue)), values,
             CalChart::ShowModeData_t{ std::get<1>(defaultValue) });
     };
     mShowModeInfos[which] = values;
@@ -659,8 +657,8 @@ void CalChartConfiguration::Clear_ShowModeData(CalChart::ShowModes which)
         throw std::runtime_error("Error, exceeding CalChart::ShowModes::NUM size");
     }
 
-    auto& defaultValue = kShowModeDefaultValues[twhich];
-    SetConfigValue<ShowModeData_t>(std::string(std::get<0>(defaultValue)), CalChart::ShowModeData_t{ std::get<1>(defaultValue) },
+    auto& defaultValue = CalChart::kShowModeDefaultValues[twhich];
+    SetConfigValue<CalChart::ShowModeData_t>(std::string(std::get<0>(defaultValue)), CalChart::ShowModeData_t{ std::get<1>(defaultValue) },
         CalChart::ShowModeData_t{ std::get<1>(defaultValue) });
     mShowModeInfos.erase(which);
 }
@@ -668,7 +666,7 @@ void CalChartConfiguration::Clear_ShowModeData(CalChart::ShowModes which)
 // Yard Lines
 std::string CalChartConfiguration::Get_yard_text(size_t which) const
 {
-    if (which >= kYardTextValues)
+    if (which >= CalChart::kYardTextValues)
         throw std::runtime_error("Error, exceeding kYardTextValues size");
 
     if (!mYardTextInfos.count(which)) {
@@ -712,14 +710,14 @@ void CalChartConfiguration::FlushWriteQueue() const
     mWriteQueue.clear();
 }
 
-ShowMode GetConfigShowMode(const std::string& which)
+CalChart::ShowMode GetConfigShowMode(const std::string& which)
 {
-    auto iter = std::find_if(std::begin(kShowModeDefaultValues), std::end(kShowModeDefaultValues), [which](auto&& t) {
+    auto iter = std::find_if(std::begin(CalChart::kShowModeDefaultValues), std::end(CalChart::kShowModeDefaultValues), [which](auto&& t) {
         return std::get<0>(t) == which;
     });
-    if (iter != std::end(kShowModeDefaultValues)) {
-        auto item = static_cast<CalChart::ShowModes>(std::distance(std::begin(kShowModeDefaultValues), iter));
-        return ShowMode::CreateShowMode(CalChartConfiguration::GetGlobalConfig().Get_ShowModeData(item), Get_yard_text_all(CalChartConfiguration::GetGlobalConfig()));
+    if (iter != std::end(CalChart::kShowModeDefaultValues)) {
+        auto item = static_cast<CalChart::ShowModes>(std::distance(std::begin(CalChart::kShowModeDefaultValues), iter));
+        return CalChart::ShowMode::CreateShowMode(CalChartConfiguration::GetGlobalConfig().Get_ShowModeData(item), Get_yard_text_all(CalChartConfiguration::GetGlobalConfig()));
     }
     throw std::runtime_error("No such show");
 }
@@ -742,10 +740,10 @@ std::vector<std::string> GetColorPaletteNames(CalChartConfiguration const& confi
     return result;
 }
 
-std::array<std::string, kYardTextValues> Get_yard_text_all(CalChartConfiguration const& config)
+std::array<std::string, CalChart::kYardTextValues> Get_yard_text_all(CalChartConfiguration const& config)
 {
-    std::array<std::string, kYardTextValues> values;
-    for (auto i = 0; i < kYardTextValues; ++i) {
+    std::array<std::string, CalChart::kYardTextValues> values;
+    for (auto i = 0; i < CalChart::kYardTextValues; ++i) {
         values[i] = config.Get_yard_text(i);
     }
     return values;

--- a/src/CalChartDrawing.cpp
+++ b/src/CalChartDrawing.cpp
@@ -597,34 +597,34 @@ namespace {
 }
 
 // this draws the yardline labels
-static void DrawText(wxDC& dc, std::string text, CalChart::Coord c, uint32_t anchor, bool withBox)
+static void DrawText(wxDC& dc, std::string text, CalChart::Coord c, CalChart::DrawCommands::Text::TextAnchor anchor, bool withBox)
 {
     auto where = fDIP(wxPoint{ c.x, c.y });
     auto textSize = dc.GetTextExtent(text);
     using TextAnchor = CalChart::DrawCommands::Text::TextAnchor;
-    if (anchor & toUType(TextAnchor::VerticalCenter)) {
+    if ((anchor & TextAnchor::VerticalCenter) == TextAnchor::VerticalCenter) {
         where.y -= textSize.y / 2;
     }
-    if (anchor & toUType(TextAnchor::Bottom)) {
+    if ((anchor & TextAnchor::Bottom) == TextAnchor::Bottom) {
         where.y -= textSize.y;
     }
-    if (anchor & toUType(TextAnchor::HorizontalCenter)) {
+    if ((anchor & TextAnchor::HorizontalCenter) == TextAnchor::HorizontalCenter) {
         where.x -= textSize.x / 2;
     }
-    if (anchor & toUType(TextAnchor::Right)) {
+    if ((anchor & TextAnchor::Right) == TextAnchor::Right) {
         where.x -= textSize.x;
     }
-    if (anchor & toUType(TextAnchor::ScreenTop)) {
+    if ((anchor & TextAnchor::ScreenTop) == TextAnchor::ScreenTop) {
         where.y = std::max(where.y, dc.DeviceToLogicalY(0));
     }
-    if (anchor & toUType(TextAnchor::ScreenBottom)) {
+    if ((anchor & TextAnchor::ScreenBottom) == TextAnchor::ScreenBottom) {
         auto edge = dc.DeviceToLogicalY(dc.GetSize().y);
         where.y = std::min(where.y, edge - textSize.y);
     }
-    if (anchor & toUType(TextAnchor::ScreenLeft)) {
+    if ((anchor & TextAnchor::ScreenLeft) == TextAnchor::ScreenLeft) {
         where.x = std::max(where.x, dc.DeviceToLogicalX(0));
     }
-    if (anchor & toUType(TextAnchor::ScreenRight)) {
+    if ((anchor & TextAnchor::ScreenRight) == TextAnchor::ScreenRight) {
         auto edge = dc.DeviceToLogicalX(dc.GetSize().x);
         where.x = std::min(where.x, edge - textSize.x);
     }
@@ -715,7 +715,6 @@ namespace CalChartDraw::Field {
         if (howToDraw != ShowMode_kPrinting) {
             // set color so when we make background box it blends
             wxCalChart::setBrushAndPen(dc, config.Get_CalChartBrushAndPen(CalChart::Colors::FIELD));
-            dc.DrawRectangle(top_row, textSize);
         }
 
         auto yard_text = std::span(mode.Get_yard_text());

--- a/src/CalChartDrawing.cpp
+++ b/src/CalChartDrawing.cpp
@@ -715,6 +715,7 @@ namespace CalChartDraw::Field {
         if (howToDraw != ShowMode_kPrinting) {
             // set color so when we make background box it blends
             wxCalChart::setBrushAndPen(dc, config.Get_CalChartBrushAndPen(CalChart::Colors::FIELD));
+            dc.DrawRectangle(top_row, textSize);
         }
 
         auto yard_text = std::span(mode.Get_yard_text());

--- a/src/ContinuityBoxDrawer.cpp
+++ b/src/ContinuityBoxDrawer.cpp
@@ -19,6 +19,7 @@
 #include "CalChartConfiguration.h"
 #include "CalChartContinuityToken.h"
 #include "CalChartDrawPrimativesHelper.h"
+#include "DCSaveRestore.h"
 #include "basic_ui.h"
 
 #include <regex>

--- a/src/ContinuityBoxDrawer.cpp
+++ b/src/ContinuityBoxDrawer.cpp
@@ -19,7 +19,6 @@
 #include "CalChartConfiguration.h"
 #include "CalChartContinuityToken.h"
 #include "CalChartDrawPrimativesHelper.h"
-#include "DCSaveRestore.h"
 #include "basic_ui.h"
 
 #include <regex>

--- a/src/ContinuityBrowserPanel.h
+++ b/src/ContinuityBrowserPanel.h
@@ -20,6 +20,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "CalChartConstants.h"
 #include "CalChartContinuity.h"
 #include "CalChartTypes.h"
 #include "CustomListViewPanel.h"

--- a/src/cc_omniview_constants.h
+++ b/src/cc_omniview_constants.h
@@ -21,23 +21,22 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define _USE_MATH_DEFINES
-#include <cmath>
+#include <numbers>
 
-static constexpr auto kViewPoint_x_1 = 0.0;
-static constexpr auto kViewPoint_y_1 = -60.0;
-static constexpr auto kViewPoint_z_1 = 20.0;
-static constexpr auto kViewAngle_1 = M_PI / 2.0;
-static constexpr auto kViewAngle_z_1 = -M_PI / 8.0;
+inline constexpr auto kViewPoint_x_1 = 0.0;
+inline constexpr auto kViewPoint_y_1 = -60.0;
+inline constexpr auto kViewPoint_z_1 = 20.0;
+inline constexpr auto kViewAngle_1 = std::numbers::pi / 2.0;
+inline constexpr auto kViewAngle_z_1 = -std::numbers::pi / 8.0;
 
-static constexpr auto kViewPoint_x_2 = 0.0;
-static constexpr auto kViewPoint_y_2 = -16.0;
-static constexpr auto kViewPoint_z_2 = 2.5;
-static constexpr auto kViewAngle_2 = M_PI / 2.0;
-static constexpr auto kViewAngle_z_2 = 0.0;
+inline constexpr auto kViewPoint_x_2 = 0.0;
+inline constexpr auto kViewPoint_y_2 = -16.0;
+inline constexpr auto kViewPoint_z_2 = 2.5;
+inline constexpr auto kViewAngle_2 = std::numbers::pi / 2.0;
+inline constexpr auto kViewAngle_z_2 = 0.0;
 
-static constexpr auto kViewPoint_x_3 = 60.0;
-static constexpr auto kViewPoint_y_3 = -55.0;
-static constexpr auto kViewPoint_z_3 = 20.0;
-static constexpr auto kViewAngle_3 = 11.0 * M_PI / 16.0;
-static constexpr auto kViewAngle_z_3 = -M_PI / 8.0;
+inline constexpr auto kViewPoint_x_3 = 60.0;
+inline constexpr auto kViewPoint_y_3 = -55.0;
+inline constexpr auto kViewPoint_z_3 = 20.0;
+inline constexpr auto kViewAngle_3 = 11.0 * std::numbers::pi / 16.0;
+inline constexpr auto kViewAngle_z_3 = -std::numbers::pi / 8.0;

--- a/src/core/CalChartAnimationCommand.cpp
+++ b/src/core/CalChartAnimationCommand.cpp
@@ -226,9 +226,7 @@ std::unique_ptr<AnimationCommand> AnimationCommandRotate::clone() const
 bool AnimationCommandRotate::NextBeat(Coord& pt)
 {
     bool b = AnimationCommand::NextBeat(pt);
-    auto curr_ang = (mNumBeats ? ((mAngEnd - mAngStart) * mBeat / mNumBeats + mAngStart)
-                               : mAngStart)
-        * M_PI / 180.0;
+    auto curr_ang = Deg2Rad(mNumBeats ? ((mAngEnd - mAngStart) * mBeat / mNumBeats + mAngStart) : mAngStart);
     pt.x = RoundToCoordUnits(mOrigin.x + cos(curr_ang) * mR);
     pt.y = RoundToCoordUnits(mOrigin.y - sin(curr_ang) * mR);
     return b;
@@ -237,9 +235,7 @@ bool AnimationCommandRotate::NextBeat(Coord& pt)
 bool AnimationCommandRotate::PrevBeat(Coord& pt)
 {
     if (AnimationCommand::PrevBeat(pt)) {
-        auto curr_ang = (mNumBeats ? ((mAngEnd - mAngStart) * mBeat / mNumBeats + mAngStart)
-                                   : mAngStart)
-            * M_PI / 180.0;
+        auto curr_ang = Deg2Rad(mNumBeats ? ((mAngEnd - mAngStart) * mBeat / mNumBeats + mAngStart) : mAngStart);
         pt.x = RoundToCoordUnits(mOrigin.x + cos(curr_ang) * mR);
         pt.y = RoundToCoordUnits(mOrigin.y - sin(curr_ang) * mR);
         return true;
@@ -251,15 +247,15 @@ bool AnimationCommandRotate::PrevBeat(Coord& pt)
 void AnimationCommandRotate::ApplyForward(Coord& pt)
 {
     AnimationCommand::ApplyForward(pt);
-    pt.x = RoundToCoordUnits(mOrigin.x + cos(mAngEnd * M_PI / 180.0) * mR);
-    pt.y = RoundToCoordUnits(mOrigin.y - sin(mAngEnd * M_PI / 180.0) * mR);
+    pt.x = RoundToCoordUnits(mOrigin.x + cos(Deg2Rad(mAngEnd)) * mR);
+    pt.y = RoundToCoordUnits(mOrigin.y - sin(Deg2Rad(mAngEnd)) * mR);
 }
 
 void AnimationCommandRotate::ApplyBackward(Coord& pt)
 {
     AnimationCommand::ApplyBackward(pt);
-    pt.x = RoundToCoordUnits(mOrigin.x + cos(mAngStart * M_PI / 180.0) * mR);
-    pt.y = RoundToCoordUnits(mOrigin.y - sin(mAngStart * M_PI / 180.0) * mR);
+    pt.x = RoundToCoordUnits(mOrigin.x + cos(Deg2Rad(mAngStart)) * mR);
+    pt.y = RoundToCoordUnits(mOrigin.y - sin(Deg2Rad(mAngStart)) * mR);
 }
 
 float AnimationCommandRotate::FacingDirection() const
@@ -284,10 +280,10 @@ AnimationCommandRotate::GenCC_DrawCommand(Coord /*pt*/, Coord offset) const
 {
     float start = (mAngStart < mAngEnd) ? mAngStart : mAngEnd;
     float end = (mAngStart < mAngEnd) ? mAngEnd : mAngStart;
-    auto x_start = RoundToCoordUnits(mOrigin.x + cos(start * M_PI / 180.0) * mR) + offset.x;
-    auto y_start = RoundToCoordUnits(mOrigin.y - sin(start * M_PI / 180.0) * mR) + offset.y;
-    auto x_end = RoundToCoordUnits(mOrigin.x + cos(end * M_PI / 180.0) * mR) + offset.x;
-    auto y_end = RoundToCoordUnits(mOrigin.y - sin(end * M_PI / 180.0) * mR) + offset.y;
+    auto x_start = RoundToCoordUnits(mOrigin.x + cos(Deg2Rad(start)) * mR) + offset.x;
+    auto y_start = RoundToCoordUnits(mOrigin.y - sin(Deg2Rad(start)) * mR) + offset.y;
+    auto x_end = RoundToCoordUnits(mOrigin.x + cos(Deg2Rad(end)) * mR) + offset.x;
+    auto y_end = RoundToCoordUnits(mOrigin.y - sin(Deg2Rad(end)) * mR) + offset.y;
 
     return DrawCommands::Arc{ x_start, y_start, x_end, y_end, mOrigin.x + offset.x, mOrigin.y + offset.y };
 }

--- a/src/core/CalChartAnimationErrors.h
+++ b/src/core/CalChartAnimationErrors.h
@@ -22,6 +22,7 @@
 */
 
 #include "CalChartAnimationTypes.h"
+#include "CalChartConstants.h"
 #include "CalChartContinuityToken.h"
 #include "CalChartTypes.h"
 #include <array>

--- a/src/core/CalChartConstants.h
+++ b/src/core/CalChartConstants.h
@@ -21,15 +21,12 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "CalChartTypes.h"
+#include "CalChartUtils.h"
 #include <array>
+#include <string>
 #include <vector>
 
 namespace CalChart {
-
-// the fudge factor for floating point math
-constexpr auto kEpsilon = 1e-6;
-constexpr auto SQRT2 = 1.4142136;
 
 enum class Colors {
     FIELD,
@@ -148,6 +145,60 @@ static const std::array<ShowModeInfo_t, toUType(ShowModes::NUM)> kShowModeDefaul
     ShowModeInfo_t{ "Old Field", { 28, 52, 8, 8, 8, 8, -80, -42, 160, 84 } },
     ShowModeInfo_t{ "Pro Field", { 36, 48, 8, 8, 8, 8, -80, -42, 160, 84 } },
 };
+
+// we lay out directions in clockwise order from North
+enum class Direction {
+    North,
+    NorthEast,
+    East,
+    SouthEast,
+    South,
+    SouthWest,
+    West,
+    NorthWest,
+};
+
+template <typename T>
+constexpr auto AngleToDirection(T ang)
+{
+    return static_cast<CalChart::Direction>(AngleToQuadrant(ang));
+}
+
+enum class PSFONT {
+    SYMBOL,
+    NORM,
+    BOLD,
+    ITAL,
+    BOLDITAL,
+    TAB
+};
+
+enum SYMBOL_TYPE {
+    SYMBOL_PLAIN = 0,
+    SYMBOL_SOL,
+    SYMBOL_BKSL,
+    SYMBOL_SL,
+    SYMBOL_X,
+    SYMBOL_SOLBKSL,
+    SYMBOL_SOLSL,
+    SYMBOL_SOLX,
+    MAX_NUM_SYMBOLS
+};
+
+static const SYMBOL_TYPE k_symbols[] = {
+    SYMBOL_PLAIN,
+    SYMBOL_SOL,
+    SYMBOL_BKSL,
+    SYMBOL_SL,
+    SYMBOL_X,
+    SYMBOL_SOLBKSL,
+    SYMBOL_SOLSL,
+    SYMBOL_SOLX
+};
+
+std::string GetNameForSymbol(SYMBOL_TYPE which);
+std::string GetLongNameForSymbol(SYMBOL_TYPE which);
+SYMBOL_TYPE GetSymbolForName(const std::string& name);
 
 namespace details {
     template <std::size_t index, typename Array, std::size_t... I>

--- a/src/core/CalChartConstants.h
+++ b/src/core/CalChartConstants.h
@@ -25,8 +25,11 @@
 #include <array>
 #include <vector>
 
-// forward declare
 namespace CalChart {
+
+// the fudge factor for floating point math
+constexpr auto kEpsilon = 1e-6;
+constexpr auto SQRT2 = 1.4142136;
 
 enum class Colors {
     FIELD,

--- a/src/core/CalChartContinuityToken.cpp
+++ b/src/core/CalChartContinuityToken.cpp
@@ -144,7 +144,7 @@ void DoCounterMarch(const Procedure& proc, AnimationCompile& anim,
     p[1] = ref1 + v1;
     auto steps2 = (ref2 - p[1]).Magnitude() * sin(Deg2Rad(ref2.Direction(p[1]) - d1)) / c;
     if (IsDiagonalDirection(d2)) {
-        steps2 /= static_cast<float>(SQRT2);
+        steps2 /= static_cast<float>(std::numbers::sqrt2);
     }
     auto v2 = CreateVector(d2, steps2);
     p[2] = p[1] + v2;
@@ -770,7 +770,7 @@ float ValueDefined::Get(AnimationCompile const&) const
         { CC_JS, 0.5 },
         { CC_GV, 1.0 },
         { CC_M, 4.0f / 3 },
-        { CC_DM, static_cast<float>(SQRT2) },
+        { CC_DM, static_cast<float>(std::numbers::sqrt2) },
     };
     auto i = mapping.find(val);
     if (i != mapping.end()) {

--- a/src/core/CalChartContinuityToken.cpp
+++ b/src/core/CalChartContinuityToken.cpp
@@ -28,6 +28,8 @@
 #include "CalChartUtils.h"
 #include "parse.h"
 
+#include <cmath>
+
 // for serialization we need to pre-register all of the different types that can exist in the inuity AST.
 
 enum class SerializationToken {

--- a/src/core/CalChartCoord.cpp
+++ b/src/core/CalChartCoord.cpp
@@ -54,8 +54,10 @@ float Coord::Direction() const
     if (*this == 0)
         return 0.0;
 
-    auto ang = acos(CoordUnits2Float(x) / Magnitude()); // normalize
-    ang *= static_cast<float>(180.0 / M_PI); // convert to degrees
+    auto ang = Rad2Deg(acos(CoordUnits2Float(x) / Magnitude())); // normalize
+    // ang = Rad2Deg<float>(ang); // normalize
+    //    ang = Rad2Deg<float>(ang); // normalize
+    // ang *= 180.0 / M_PI;
     if (y > 0)
         ang = (-ang); // check for > PI
 

--- a/src/core/CalChartCoord.cpp
+++ b/src/core/CalChartCoord.cpp
@@ -55,9 +55,6 @@ float Coord::Direction() const
         return 0.0;
 
     auto ang = Rad2Deg(acos(CoordUnits2Float(x) / Magnitude())); // normalize
-    // ang = Rad2Deg<float>(ang); // normalize
-    //    ang = Rad2Deg<float>(ang); // normalize
-    // ang *= 180.0 / M_PI;
     if (y > 0)
         ang = (-ang); // check for > PI
 

--- a/src/core/CalChartCoord.h
+++ b/src/core/CalChartCoord.h
@@ -28,8 +28,8 @@
 
 namespace CalChart {
 
-constexpr auto kCoordShift = 4;
-constexpr auto kCoordDecimal = (1 << kCoordShift);
+inline constexpr auto kCoordShift = 4;
+inline constexpr auto kCoordDecimal = (1 << kCoordShift);
 
 struct Coord {
     using units = int16_t;
@@ -159,7 +159,7 @@ constexpr auto Float2CoordUnits(T a)
 template <typename T>
 constexpr auto CoordUnits2Float(T a)
 {
-    return a / (float)CalChart::kCoordDecimal;
+    return a / static_cast<double>(CalChart::kCoordDecimal);
 }
 
 // Int2CoordUnits, CoordUnits2Int

--- a/src/core/CalChartDrawCommand.cpp
+++ b/src/core/CalChartDrawCommand.cpp
@@ -76,8 +76,8 @@ namespace Point {
             break;
         }
         if (point.LabelIsVisible()) {
-            auto anchor = toUType(CalChart::DrawCommands::Text::TextAnchor::Bottom);
-            anchor |= point.GetFlip() ? toUType(CalChart::DrawCommands::Text::TextAnchor::Left) : toUType(CalChart::DrawCommands::Text::TextAnchor::Right);
+            auto anchor = CalChart::DrawCommands::Text::TextAnchor::Bottom;
+            anchor = anchor | (point.GetFlip() ? CalChart::DrawCommands::Text::TextAnchor::Left : CalChart::DrawCommands::Text::TextAnchor::Right);
             drawCmds.push_back(CalChart::DrawCommands::Text(pos - CalChart::Coord(0, circ_r), label, anchor));
         }
         return drawCmds;
@@ -190,8 +190,8 @@ namespace Field {
             auto text = yard_text[i];
 
             using TextAnchor = CalChart::DrawCommands::Text::TextAnchor;
-            result.emplace_back(CalChart::DrawCommands::Text{ CalChart::Coord(i * step8 + border1.x, border1.y + offset), text, toUType(TextAnchor::Bottom) | toUType(TextAnchor::HorizontalCenter) | toUType(TextAnchor::ScreenTop), true });
-            result.emplace_back(CalChart::DrawCommands::Text{ CalChart::Coord(i * step8 + border1.x, border1.y + fieldsize.y - offset), text, toUType(TextAnchor::Top) | toUType(TextAnchor::HorizontalCenter), true });
+            result.emplace_back(CalChart::DrawCommands::Text{ CalChart::Coord(i * step8 + border1.x, border1.y + offset), text, TextAnchor::Bottom | TextAnchor::HorizontalCenter | TextAnchor::ScreenTop, true });
+            result.emplace_back(CalChart::DrawCommands::Text{ CalChart::Coord(i * step8 + border1.x, border1.y + fieldsize.y - offset), text, TextAnchor::Top | TextAnchor::HorizontalCenter, true });
         }
         return result;
     }

--- a/src/core/CalChartDrawCommand.h
+++ b/src/core/CalChartDrawCommand.h
@@ -21,6 +21,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "CalChartConstants.h"
 #include "CalChartCoord.h"
 #include <span>
 #include <variant>
@@ -128,14 +129,13 @@ namespace DrawCommands {
             ScreenRight = 1 << 8,
             ScreenLeft = 1 << 9,
         };
-        using TextAnchor_t = std::underlying_type_t<TextAnchor>;
 
         int x{}, y{};
         std::string text;
-        TextAnchor_t anchor{};
+        TextAnchor anchor{};
         bool withBackground{};
 
-        Text(int startx, int starty, std::string const& text = "", TextAnchor_t anchor = toUType(TextAnchor::None), bool withBackground = false)
+        Text(int startx, int starty, std::string const& text = "", TextAnchor anchor = TextAnchor::None, bool withBackground = false)
             : x(startx)
             , y(starty)
             , text(text)
@@ -144,11 +144,19 @@ namespace DrawCommands {
         {
         }
 
-        Text(Coord start, std::string const& text = "", TextAnchor_t anchor = toUType(TextAnchor::None), bool withBackground = false)
+        Text(Coord start, std::string const& text = "", TextAnchor anchor = TextAnchor::None, bool withBackground = false)
             : Text(start.x, start.y, text, anchor, withBackground)
         {
         }
     };
+    inline Text::TextAnchor operator|(Text::TextAnchor lhs, Text::TextAnchor rhs)
+    {
+        return static_cast<Text::TextAnchor>(toUType(lhs) | toUType(rhs));
+    }
+    inline Text::TextAnchor operator&(Text::TextAnchor lhs, Text::TextAnchor rhs)
+    {
+        return static_cast<Text::TextAnchor>(toUType(lhs) & toUType(rhs));
+    }
 
 }
 

--- a/src/core/CalChartMovePointsTool.cpp
+++ b/src/core/CalChartMovePointsTool.cpp
@@ -332,22 +332,21 @@ std::map<int, CalChart::Coord> MovePointsTool_MoveShear::TransformPoints(std::ma
 {
     if (m_shape_list.size() < 2) {
         return select_list;
-    } else {
-        assert(m_shape_list.size() == 2);
-        auto start = dynamic_cast<CalChart::Shape_1point&>(*m_shape_list[0]).GetOrigin();
-        auto* shape = (CalChart::Shape_2point const*)m_shape_list.back().get();
-        auto c1 = shape->GetOrigin();
-        auto c2 = shape->GetPoint();
-        auto v1 = c1 - start;
-        auto v2 = c2 - c1;
-        float amount = v2.Magnitude() / v1.Magnitude();
-        if (BoundDirectionSigned(v1.Direction() - (c2 - start).Direction()) < 0) {
-            amount = -amount;
-        }
-        float ang = -v1.Direction() * M_PI / 180.0;
-        auto m = TranslationMatrix(Vector<float>(-start.x, -start.y, 0)) * ZRotationMatrix(-ang) * YXShearMatrix(amount) * ZRotationMatrix(ang) * TranslationMatrix(Vector<float>(start.x, start.y, 0));
-        return GetTransformedPoints(m, select_list);
     }
+    assert(m_shape_list.size() == 2);
+    auto start = dynamic_cast<CalChart::Shape_1point&>(*m_shape_list[0]).GetOrigin();
+    auto* shape = (CalChart::Shape_2point const*)m_shape_list.back().get();
+    auto c1 = shape->GetOrigin();
+    auto c2 = shape->GetPoint();
+    auto v1 = c1 - start;
+    auto v2 = c2 - c1;
+    float amount = v2.Magnitude() / v1.Magnitude();
+    if (BoundDirectionSigned(v1.Direction() - (c2 - start).Direction()) < 0) {
+        amount = -amount;
+    }
+    float ang = Deg2Rad(-v1.Direction());
+    auto m = TranslationMatrix(Vector<float>(-start.x, -start.y, 0)) * ZRotationMatrix(-ang) * YXShearMatrix(amount) * ZRotationMatrix(ang) * TranslationMatrix(Vector<float>(start.x, start.y, 0));
+    return GetTransformedPoints(m, select_list);
 }
 
 void MovePointsTool_MoveShear::OnClickUp(CalChart::Coord pos)
@@ -386,7 +385,7 @@ std::map<int, CalChart::Coord> MovePointsTool_MoveReflect::TransformPoints(std::
     auto* shape = (CalChart::Shape_2point const*)m_shape_list.back().get();
     auto c1 = shape->GetOrigin();
     auto c2 = shape->GetPoint() - c1;
-    float ang = -c2.Direction() * M_PI / 180.0;
+    float ang = Deg2Rad(-c2.Direction());
     auto m = TranslationMatrix(Vector<float>(-c1.x, -c1.y, 0)) * ZRotationMatrix(-ang) * YReflectionMatrix<float>() * ZRotationMatrix(ang) * TranslationMatrix(Vector<float>(c1.x, c1.y, 0));
     return GetTransformedPoints(m, select_list);
 }
@@ -555,12 +554,12 @@ std::map<int, CalChart::Coord> MovePointsTool_ShapeEllipse::TransformPoints(std:
     const auto a = (end.x - start.x) / 2.0;
     const auto b = (end.y - start.y) / 2.0;
     std::map<int, CalChart::Coord> result;
-    auto amount = (2.0 * M_PI) / select_list.size();
-    auto angle = -M_PI / 2.0;
+    auto amount = (2.0 * std::numbers::pi) / select_list.size();
+    auto angle = -std::numbers::pi / 2.0;
     auto ordered = get_ordered_selection(select_list);
     for (auto i : ordered) {
         // should this have a snap to grid?
-        if ((angle > M_PI / 2.0) && (angle <= 3.0 * M_PI / 2.0)) {
+        if ((angle > std::numbers::pi / 2.0) && (angle <= 3.0 * std::numbers::pi / 2.0)) {
             result[i] = center + CalChart::Coord(-(a * b) / (sqrt(pow(b, 2) + pow(a, 2) * pow(tan(angle), 2))), -(a * b * tan(angle)) / (sqrt(pow(b, 2) + pow(a, 2) * pow(tan(angle), 2))));
         } else {
             result[i] = center + CalChart::Coord((a * b) / (sqrt(pow(b, 2) + pow(a, 2) * pow(tan(angle), 2))), (a * b * tan(angle)) / (sqrt(pow(b, 2) + pow(a, 2) * pow(tan(angle), 2))));

--- a/src/core/CalChartPoint.h
+++ b/src/core/CalChartPoint.h
@@ -32,6 +32,7 @@
  *  likely need to continue to be in Point.
  */
 
+#include "CalChartConstants.h"
 #include "CalChartCoord.h"
 #include "CalChartTypes.h"
 

--- a/src/core/CalChartShapes.cpp
+++ b/src/core/CalChartShapes.cpp
@@ -165,7 +165,7 @@ Shape_arc::Shape_arc(Coord c, Coord p)
 {
     auto p1 = p - c;
 
-    r = r0 = p1.Direction() * M_PI / 180.0;
+    r = r0 = Deg2Rad(p1.Direction());
     d = p1.Magnitude() * kCoordDecimal;
 }
 
@@ -183,7 +183,7 @@ void Shape_arc::OnMove(Coord, Coord snapped_p)
 {
     auto p1 = snapped_p;
 
-    r = GetOrigin().Direction(p1) * M_PI / 180.0;
+    r = Deg2Rad(GetOrigin().Direction(p1));
     p1.x = Coord::units(origin.x + d * cos(r));
     p1.y = Coord::units(origin.y + -d * sin(r));
     MovePoint(p1);

--- a/src/core/CalChartText.h
+++ b/src/core/CalChartText.h
@@ -21,7 +21,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "CalChartTypes.h"
+#include "CalChartConstants.h"
 
 #include <string>
 #include <vector>

--- a/src/core/CalChartTypes.h
+++ b/src/core/CalChartTypes.h
@@ -21,59 +21,12 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "CalChartUtils.h"
 #include <functional>
 #include <set>
 #include <string>
 
 namespace CalChart {
-
-enum class PSFONT {
-    SYMBOL,
-    NORM,
-    BOLD,
-    ITAL,
-    BOLDITAL,
-    TAB
-};
-
-enum SYMBOL_TYPE {
-    SYMBOL_PLAIN = 0,
-    SYMBOL_SOL,
-    SYMBOL_BKSL,
-    SYMBOL_SL,
-    SYMBOL_X,
-    SYMBOL_SOLBKSL,
-    SYMBOL_SOLSL,
-    SYMBOL_SOLX,
-    MAX_NUM_SYMBOLS
-};
-
-static const SYMBOL_TYPE k_symbols[] = {
-    SYMBOL_PLAIN,
-    SYMBOL_SOL,
-    SYMBOL_BKSL,
-    SYMBOL_SL,
-    SYMBOL_X,
-    SYMBOL_SOLBKSL,
-    SYMBOL_SOLSL,
-    SYMBOL_SOLX
-};
-
-// we lay out directions in clockwise order from North
-enum class Direction {
-    North,
-    NorthEast,
-    East,
-    SouthEast,
-    South,
-    SouthWest,
-    West,
-    NorthWest,
-};
-
-std::string GetNameForSymbol(SYMBOL_TYPE which);
-std::string GetLongNameForSymbol(SYMBOL_TYPE which);
-SYMBOL_TYPE GetSymbolForName(const std::string& name);
 
 // error occurred on parsing.  First arg is what went wrong, second is the values that need to be fixed.
 // return a string of what to try parsing.
@@ -85,10 +38,4 @@ struct ParseErrorHandlers {
 
 typedef std::set<int> SelectionList;
 
-}
-
-template <typename E>
-constexpr auto toUType(E enumerator)
-{
-    return static_cast<std::underlying_type_t<E>>(enumerator);
 }

--- a/src/core/CalChartUtils.h
+++ b/src/core/CalChartUtils.h
@@ -22,18 +22,21 @@
 */
 
 #include <cmath>
-#include <cstdlib>
 #include <numbers>
 #include <tuple>
 
-#include "CalChartConstants.h"
-#include "CalChartTypes.h"
-
 namespace CalChart {
-struct Coord;
 
+/**
+ * Math Utilities
+ */
 template <typename T>
-constexpr auto IS_ZERO(T a) { return std::abs(a) < kEpsilon; }
+inline auto IS_ZERO(T a)
+{
+    // the fudge factor for floating point math
+    constexpr auto kEpsilon = 1e-6;
+    return std::abs(a) < kEpsilon;
+}
 template <typename T>
 constexpr auto Deg2Rad(T a) { return a * std::numbers::pi / 180.0; }
 template <typename T>
@@ -42,30 +45,36 @@ constexpr auto Rad2Deg(T a) { return a * 180.0 / std::numbers::pi; }
 template <typename T>
 constexpr auto BoundDirection(T f)
 {
-    while (f >= 360.0)
+    while (f >= 360.0) {
         f -= 360.0;
-    while (f < 0.0)
+    }
+    while (f < 0.0) {
         f += 360.0;
+    }
     return f;
 }
 
 template <typename T>
-T BoundDirectionSigned(T f)
+constexpr auto BoundDirectionSigned(T f)
 {
-    while (f >= 180.0)
+    while (f >= 180.0) {
         f -= 360.0;
-    while (f < -180.0)
+    }
+    while (f < -180.0) {
         f += 360.0;
+    }
     return f;
 }
 
 template <typename T>
 constexpr auto BoundDirectionRad(T f)
 {
-    while (f >= 2 * std::numbers::pi)
+    while (f >= 2 * std::numbers::pi) {
         f -= 2 * std::numbers::pi;
-    while (f < 0.0)
+    }
+    while (f < 0.0) {
         f += 2 * std::numbers::pi;
+    }
     return f;
 }
 
@@ -76,7 +85,7 @@ constexpr auto NormalizeAngleRad(T ang) { return BoundDirectionRad(ang); }
 
 // we assume the layout of quadrants are
 template <typename T>
-auto AngleToQuadrant(T ang)
+constexpr auto AngleToQuadrant(T ang)
 {
     // rotate angle by 22.5:
     auto ang1 = ang + 22.5;
@@ -86,32 +95,92 @@ auto AngleToQuadrant(T ang)
 }
 
 template <typename T>
-auto AngleToDirection(T ang)
-{
-    return static_cast<CalChart::Direction>(AngleToQuadrant(ang));
-}
-
-template <typename T>
-auto IsDiagonalDirection(T f)
+inline auto IsDiagonalDirection(T f)
 {
     f = BoundDirection(f);
     return (IS_ZERO(f - 45.0) || IS_ZERO(f - 135.0) || IS_ZERO(f - 225.0) || IS_ZERO(f - 315.0));
 }
 
 template <typename T>
-auto CreateUnitVector(T dir)
+inline auto CreateUnitVector(T dir)
 {
     dir = -BoundDirection(dir);
     auto result = std::tuple<decltype(dir), decltype(dir)>{ cos(Deg2Rad(dir)), sin(Deg2Rad(dir)) };
     // we 'normalize' the diagonal direction to 1,1 because that be the CalChart way.
     if (IsDiagonalDirection(dir)) {
-        std::get<0>(result) /= SQRT2 / 2;
-        std::get<1>(result) /= SQRT2 / 2;
+        std::get<0>(result) /= std::numbers::sqrt2 / 2;
+        std::get<1>(result) /= std::numbers::sqrt2 / 2;
     }
     if (dir > 180) {
         std::get<1>(result) = -std::get<1>(result);
     }
     return result;
 }
+
+/**
+ * Common utils
+ */
+template <typename E>
+constexpr auto toUType(E enumerator)
+{
+    return static_cast<std::underlying_type_t<E>>(enumerator);
+}
+
+// from https://stackoverflow.com/questions/261963/how-can-i-iterate-over-an-enum
+template <typename C, C beginVal, C endVal>
+class Iterator {
+    using val_t = typename std::underlying_type<C>::type;
+    val_t val;
+
+public:
+    explicit Iterator(const C& f)
+        : val(static_cast<val_t>(f))
+    {
+    }
+    Iterator()
+        : val(static_cast<val_t>(beginVal))
+    {
+    }
+    auto operator++() -> Iterator
+    {
+        ++val;
+        return *this;
+    }
+    auto operator*() const { return static_cast<C>(val); }
+    auto begin() const -> Iterator { return *this; } // default ctor is good
+    auto end() const -> Iterator
+    {
+        static const Iterator endIter = ++Iterator(endVal); // cache it
+        return endIter;
+    }
+    auto operator!=(const Iterator& i) const { return val != i.val; }
+};
+
+// static tests
+static_assert(Deg2Rad(180.0) == std::numbers::pi);
+static_assert(Rad2Deg(std::numbers::pi) == 180.0);
+static_assert(BoundDirection(1082.0) == 2.0);
+static_assert(BoundDirection(2.0) == 2.0);
+static_assert(BoundDirection(-1082.0) == 358.0);
+static_assert(BoundDirection(-2.0) == 358.0);
+static_assert(BoundDirectionSigned(182.0) == -178.0);
+static_assert(BoundDirectionSigned(-182.0) == 178.0);
+static_assert(BoundDirectionRad(2.0) == 2.0);
+static_assert(BoundDirectionRad(-2.0) == 2 * (std::numbers::pi - 1.0));
+static_assert(BoundDirection(1082.0) == NormalizeAngle(1082.0));
+static_assert(BoundDirectionRad(-2.0) == NormalizeAngleRad(-2.0));
+static_assert(AngleToQuadrant(0) == 0);
+static_assert(AngleToQuadrant(44) == 7);
+static_assert(AngleToQuadrant(45) == 7);
+static_assert(AngleToQuadrant(90) == 6);
+static_assert(AngleToQuadrant(135) == 5);
+static_assert(AngleToQuadrant(160) == 4);
+static_assert(AngleToQuadrant(180) == 4);
+static_assert(AngleToQuadrant(225) == 3);
+static_assert(AngleToQuadrant(270) == 2);
+static_assert(AngleToQuadrant(315) == 1);
+static_assert(AngleToQuadrant(350) == 0);
+static_assert(AngleToQuadrant(360) == 0);
+static_assert(AngleToQuadrant(341341) == 7);
 
 }

--- a/src/core/CalChartUtils.h
+++ b/src/core/CalChartUtils.h
@@ -21,30 +21,23 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <cstdlib>
+#include <numbers>
 #include <tuple>
 
+#include "CalChartConstants.h"
 #include "CalChartTypes.h"
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
 
 namespace CalChart {
 struct Coord;
-}
-
-constexpr auto kEpsilon = 0.00001;
-constexpr auto SQRT2 = 1.4142136;
 
 template <typename T>
 constexpr auto IS_ZERO(T a) { return std::abs(a) < kEpsilon; }
 template <typename T>
-constexpr auto Deg2Rad(T a) { return a * M_PI / 180.0; }
+constexpr auto Deg2Rad(T a) { return a * std::numbers::pi / 180.0; }
 template <typename T>
-constexpr auto Rad2Deg(T a) { return a * 180.0 / M_PI; }
+constexpr auto Rad2Deg(T a) { return a * 180.0 / std::numbers::pi; }
 
 template <typename T>
 constexpr auto BoundDirection(T f)
@@ -69,10 +62,10 @@ T BoundDirectionSigned(T f)
 template <typename T>
 constexpr auto BoundDirectionRad(T f)
 {
-    while (f >= 2 * M_PI)
-        f -= 2 * M_PI;
+    while (f >= 2 * std::numbers::pi)
+        f -= 2 * std::numbers::pi;
     while (f < 0.0)
-        f += 2 * M_PI;
+        f += 2 * std::numbers::pi;
     return f;
 }
 
@@ -119,4 +112,6 @@ auto CreateUnitVector(T dir)
         std::get<1>(result) = -std::get<1>(result);
     }
     return result;
+}
+
 }

--- a/src/core/print_ps.cpp
+++ b/src/core/print_ps.cpp
@@ -143,10 +143,10 @@ CalcAllValues(bool PrintLandscape, bool PrintDoCont, bool overview,
 
     auto fullsize = mode.Size();
     auto fieldsize = mode.FieldSize();
-    float fullwidth = CoordUnits2Float(fullsize.x);
-    float fullheight = CoordUnits2Float(fullsize.y);
-    float fieldwidth = CoordUnits2Float(fieldsize.x);
-    float fieldheight = CoordUnits2Float(fieldsize.y);
+    auto fullwidth = CoordUnits2Float(fullsize.x);
+    auto fullheight = CoordUnits2Float(fullsize.y);
+    auto fieldwidth = CoordUnits2Float(fieldsize.x);
+    auto fieldheight = CoordUnits2Float(fieldsize.y);
 
     /* first, calculate dimensions */
     if (!overview) {
@@ -641,11 +641,11 @@ void PrintShowToPS::PrintStandard(std::ostream& buffer, const Sheet& sheet,
     for (auto i = 0; i < mShow.GetNumPoints(); i++) {
         if ((sheet.GetPoint(i).GetPos().x > clip_n) || (sheet.GetPoint(i).GetPos().x < clip_s))
             continue;
-        float fieldheight = CoordUnits2Float(fieldsize.y);
-        float fieldoffx = CoordUnits2Float(fieldoff.x);
-        float fieldoffy = CoordUnits2Float(fieldoff.y);
-        float dot_x = (CoordUnits2Float(sheet.GetPoint(i).GetPos().x) - fieldoffx - step_offset) / step_width * field_w;
-        float dot_y = (1.0 - (CoordUnits2Float(sheet.GetPoint(i).GetPos().y) - fieldoffy) / fieldheight) * field_h;
+        auto fieldheight = CoordUnits2Float(fieldsize.y);
+        auto fieldoffx = CoordUnits2Float(fieldoff.x);
+        auto fieldoffy = CoordUnits2Float(fieldoff.y);
+        auto dot_x = (CoordUnits2Float(sheet.GetPoint(i).GetPos().x) - fieldoffx - step_offset) / step_width * field_w;
+        auto dot_y = (1.0 - (CoordUnits2Float(sheet.GetPoint(i).GetPos().y) - fieldoffy) / fieldheight) * field_h;
         buffer << dot_x << " " << dot_y << " "
                << dot_routines[sheet.GetSymbol(i)] << "\n";
         buffer << "(" << mShow.GetPointLabel(i) << ") " << dot_x << " " << dot_y
@@ -668,12 +668,12 @@ void PrintShowToPS::PrintOverview(std::ostream& buffer,
     buffer << "drawfield\n";
     auto fieldoff = mMode.FieldOffset();
     auto fieldsize = mMode.FieldSize();
-    float fieldwidth = CoordUnits2Float(fieldsize.x);
+    auto fieldwidth = CoordUnits2Float(fieldsize.x);
     buffer << "/w " << (width / fieldwidth * 2.0 / 3.0) << " def\n";
 
-    float fieldx = CoordUnits2Float(fieldoff.x);
-    float fieldy = CoordUnits2Float(fieldoff.y);
-    float fieldheight = CoordUnits2Float(fieldsize.y);
+    auto fieldx = CoordUnits2Float(fieldoff.x);
+    auto fieldy = CoordUnits2Float(fieldoff.y);
+    auto fieldheight = CoordUnits2Float(fieldsize.y);
 
     for (auto i = 0; i < mShow.GetNumPoints(); i++) {
         buffer << ((CoordUnits2Float(sheet.GetPoint(i).GetPos().x) - fieldx) / fieldwidth * width)

--- a/src/core/print_ps.h
+++ b/src/core/print_ps.h
@@ -21,7 +21,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "CalChartTypes.h"
+#include "CalChartConstants.h"
 
 #include <array>
 #include <functional>

--- a/src/core/viewer_translate.h
+++ b/src/core/viewer_translate.h
@@ -6,8 +6,8 @@
  */
 //
 
+#include "CalChartConstants.h"
 #include "CalChartCoord.h"
-#include "CalChartTypes.h"
 
 namespace CalChart {
 

--- a/tests/CalChartCoordTests.cpp
+++ b/tests/CalChartCoordTests.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Basic", "CalChartCoord")
     REQUIRE(0.0 == undertest.Direction());
 
     auto undertest2 = CalChart::Coord{ 16, 16 };
-    CHECK(IS_ZERO(SQRT2 - undertest2.Magnitude()));
+    CHECK(CalChart::IS_ZERO(CalChart::SQRT2 - undertest2.Magnitude()));
     CHECK(1.0f == undertest2.DM_Magnitude());
     CHECK(-45.0 == undertest2.Direction());
 }

--- a/tests/CalChartCoordTests.cpp
+++ b/tests/CalChartCoordTests.cpp
@@ -11,7 +11,7 @@ TEST_CASE("Basic", "CalChartCoord")
     REQUIRE(0.0 == undertest.Direction());
 
     auto undertest2 = CalChart::Coord{ 16, 16 };
-    CHECK(CalChart::IS_ZERO(CalChart::SQRT2 - undertest2.Magnitude()));
+    CHECK(CalChart::IS_ZERO(std::numbers::sqrt2 - undertest2.Magnitude()));
     CHECK(1.0f == undertest2.DM_Magnitude());
     CHECK(-45.0 == undertest2.Direction());
 }

--- a/tests/CalChartDrawCommandTests.cpp
+++ b/tests/CalChartDrawCommandTests.cpp
@@ -357,25 +357,25 @@ TEST_CASE("DrawCommand")
         CHECK(uut.x == 3);
         CHECK(uut.y == 7);
         CHECK(uut.text == "A");
-        CHECK(uut.anchor == (toUType(TextAnchor::Bottom) | toUType(TextAnchor::HorizontalCenter) | toUType(TextAnchor::ScreenTop)));
+        CHECK(uut.anchor == (TextAnchor::Bottom | TextAnchor::HorizontalCenter | TextAnchor::ScreenTop));
         CHECK(uut.withBackground);
         uut = std::get<CalChart::DrawCommands::Text>(cmds[1]);
         CHECK(uut.x == 3);
         CHECK(uut.y == 8);
         CHECK(uut.text == "A");
-        CHECK(uut.anchor == (toUType(TextAnchor::Top) | toUType(TextAnchor::HorizontalCenter)));
+        CHECK(uut.anchor == (TextAnchor::Top | TextAnchor::HorizontalCenter));
         CHECK(uut.withBackground);
         uut = std::get<CalChart::DrawCommands::Text>(cmds[2]);
         CHECK(uut.x == 11);
         CHECK(uut.y == 7);
         CHECK(uut.text == "B");
-        CHECK(uut.anchor == (toUType(TextAnchor::Bottom) | toUType(TextAnchor::HorizontalCenter) | toUType(TextAnchor::ScreenTop)));
+        CHECK(uut.anchor == (TextAnchor::Bottom | TextAnchor::HorizontalCenter | TextAnchor::ScreenTop));
         CHECK(uut.withBackground);
         uut = std::get<CalChart::DrawCommands::Text>(cmds[3]);
         CHECK(uut.x == 11);
         CHECK(uut.y == 8);
         CHECK(uut.text == "B");
-        CHECK(uut.anchor == (toUType(TextAnchor::Top) | toUType(TextAnchor::HorizontalCenter)));
+        CHECK(uut.anchor == (TextAnchor::Top | TextAnchor::HorizontalCenter));
         CHECK(uut.withBackground);
     }
 }

--- a/tests/CalChartUtilsTests.cpp
+++ b/tests/CalChartUtilsTests.cpp
@@ -5,21 +5,21 @@
 
 TEST_CASE("CalChartUtils", "basics")
 {
-
+    using namespace CalChart;
     CHECK_FALSE(IS_ZERO(1.0));
     CHECK(IS_ZERO(1.0e-9));
 
     CHECK(Deg2Rad(0) == 0);
     CHECK_FALSE(Deg2Rad(1) == 0);
     CHECK_FALSE(Deg2Rad(1) == 1.0f);
-    CHECK(IS_ZERO(Deg2Rad(180) - M_PI));
-    CHECK(IS_ZERO(Deg2Rad(225) - 5.0 / 4.0 * M_PI));
-    CHECK(IS_ZERO(Deg2Rad(360) - 2 * M_PI));
-    CHECK(IS_ZERO(Deg2Rad(540) - 3 * M_PI));
-    CHECK(IS_ZERO(Rad2Deg(M_PI) - 180));
-    CHECK(IS_ZERO(Rad2Deg(5.0 / 4.0 * M_PI) - 225));
-    CHECK(IS_ZERO(Rad2Deg(2 * M_PI) - 360));
-    CHECK(IS_ZERO(Rad2Deg(3 * M_PI) - 540));
+    CHECK(IS_ZERO(Deg2Rad(180) - std::numbers::pi));
+    CHECK(IS_ZERO(Deg2Rad(225) - 5.0 / 4.0 * std::numbers::pi));
+    CHECK(IS_ZERO(Deg2Rad(360) - 2 * std::numbers::pi));
+    CHECK(IS_ZERO(Deg2Rad(540) - 3 * std::numbers::pi));
+    CHECK(IS_ZERO(Rad2Deg(std::numbers::pi) - 180));
+    CHECK(IS_ZERO(Rad2Deg(5.0 / 4.0 * std::numbers::pi) - 225));
+    CHECK(IS_ZERO(Rad2Deg(2 * std::numbers::pi) - 360));
+    CHECK(IS_ZERO(Rad2Deg(3 * std::numbers::pi) - 540));
 
     CHECK(BoundDirection(225) == 225);
     CHECK(BoundDirection(-225) == 135);

--- a/tests/CalChartUtilsTests.cpp
+++ b/tests/CalChartUtilsTests.cpp
@@ -1,3 +1,4 @@
+#include "CalChartConstants.h"
 #include "CalChartUtils.h"
 #include <catch2/catch_test_macros.hpp>
 #include <iostream>


### PR DESCRIPTION
Using more std::numerics instead of `#defines` for constants.

Moving constants into a central place.

Using more clang-tidy results.