### PR TITLE
Issue #444: Continuity view on main frame looks wrong

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,7 +58,7 @@ jobs:
       if: matrix.config.os == 'macos-13'
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '14.3.1'
+        xcode-version: '15.0.1'
 
     - name: Installing Dependencies (Windows)
       if: matrix.config.os == 'windows-latest'

--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 Bugs addressed in this release:
 
 * [#404](../../issues/404) Crash when sheet has zero beats.
+* [#444](../../issues/444) Continuity view on main frame looks wrong
 
 Other changes:
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -37,8 +37,8 @@ set(wxUSE_STC OFF)
 set(wxUSE_STD_CONTAINERS ON)
 FetchContent_Declare(
   wxWidgets
-  GIT_REPOSITORY "https://github.com/wxWidgets/wxWidgets"
-  GIT_TAG a812fffda3fe686c94e24bff27e8effd96e4de64 # v3.2.2.1
+  GIT_REPOSITORY "https://github.com/rmpowell77/wxWidgets.git"
+  GIT_TAG 1e53b7f804073e6cf4903935fb7f9cccaf05e22f # v3.2.4_wxAUI_fix
 )
 FetchContent_MakeAvailable(wxWidgets)
 

--- a/src/CalChartConfiguration.cpp
+++ b/src/CalChartConfiguration.cpp
@@ -518,7 +518,7 @@ Get_BrushAndPen(Color c, Map& colorsAndWidth, InfoDefault const& InfoDefaultArra
             CalChartConfiguration::ColorWidth_t(wxCalChart::toColor(std::get<1>(InfoDefaultArray[toUType(c)])), std::get<2>(InfoDefaultArray[toUType(c)])));
     }
     auto colorAndWidth = colorsAndWidth[c];
-    return { std::get<0>(colorAndWidth), CalChart::Brush::Style::Solid, std::get<1>(colorAndWidth) };
+    return { std::get<0>(colorAndWidth), CalChart::Brush::Style::Solid, CalChart::Pen::Style::Solid, std::get<1>(colorAndWidth) };
 }
 
 template <typename Color, typename Map, typename InfoDefault, typename WriteQueue>

--- a/src/CalChartDrawPrimativesHelper.h
+++ b/src/CalChartDrawPrimativesHelper.h
@@ -55,7 +55,7 @@ inline auto toBrush(CalChart::Brush b)
 
 inline auto toBrush(CalChart::BrushAndPen b)
 {
-    if (b.style == CalChart::Brush::Style::Transparent) {
+    if (b.brushStyle == CalChart::Brush::Style::Transparent) {
         return *wxTRANSPARENT_BRUSH;
     }
     return *wxTheBrushList->FindOrCreateBrush(toColour(b.color));
@@ -68,10 +68,13 @@ inline auto toPen(CalChart::Pen p)
 
 inline auto toPen(CalChart::BrushAndPen b)
 {
-    if (b.style == CalChart::Brush::Style::Transparent) {
+    if (b.brushStyle == CalChart::Brush::Style::Transparent) {
         return *wxTRANSPARENT_PEN;
     }
-    return *wxThePenList->FindOrCreatePen(toColour(b.color), b.width);
+    auto penStyle = b.penStyle == CalChart::Pen::Style::ShortDash ? wxPENSTYLE_SHORT_DASH
+                                                                  : wxPENSTYLE_SOLID;
+
+    return *wxThePenList->FindOrCreatePen(toColour(b.color), b.width, penStyle);
 }
 
 inline auto toColor(wxColour const& c)
@@ -91,22 +94,25 @@ inline auto toBrush(wxBrush const& b)
 
 inline auto toPen(wxPen const& p)
 {
-    return CalChart::Pen{ toColor(p.GetColour()), p.GetWidth() };
+    auto penStyle = p.GetStyle() == wxPENSTYLE_SHORT_DASH
+        ? CalChart::Pen::Style::ShortDash
+        : CalChart::Pen::Style::Solid;
+    return CalChart::Pen{ toColor(p.GetColour()), penStyle, p.GetWidth() };
 }
 
 inline auto toBrushAndPen(wxColour const& c, int width)
 {
-    return CalChart::BrushAndPen{ toColor(c), CalChart::Brush::Style::Solid, width };
+    return CalChart::BrushAndPen{ toColor(c), CalChart::Brush::Style::Solid, CalChart::Pen::Style::Solid, width };
 }
 
 inline auto toBrushAndPen(std::string_view s, int width)
 {
-    return CalChart::BrushAndPen{ toColor(s), CalChart::Brush::Style::Solid, width };
+    return CalChart::BrushAndPen{ toColor(s), CalChart::Brush::Style::Solid, CalChart::Pen::Style::Solid, width };
 }
 
 inline auto toBrushAndPen(wxPen const& p)
 {
-    return CalChart::BrushAndPen{ toColor(p.GetColour()), CalChart::Brush::Style::Solid, p.GetWidth() };
+    return CalChart::BrushAndPen{ toColor(p.GetColour()), CalChart::Brush::Style::Solid, CalChart::Pen::Style::Solid, p.GetWidth() };
 }
 
 inline auto setBackground(wxDC& dc, CalChart::Color color)

--- a/src/CalChartView.cpp
+++ b/src/CalChartView.cpp
@@ -19,6 +19,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define _LIBCPP_ENABLE_EXPERIMENTAL 1
 #include "CalChartView.h"
 #include "BackgroundImages.h"
 #include "CalChartAnimation.h"

--- a/src/ContinuityBoxDrawer.h
+++ b/src/ContinuityBoxDrawer.h
@@ -32,12 +32,12 @@ class ContinuityBoxSubPartDrawer;
 class ContinuityBoxDrawer : public DrawableCell {
 public:
     ContinuityBoxDrawer(CalChart::Cont::Drawable const& proc, CalChartConfiguration const& config, std::function<void(CalChart::Cont::Drawable const&)> action = nullptr);
-    virtual ~ContinuityBoxDrawer();
+    ~ContinuityBoxDrawer() override;
     void SetHighlight(void const* ptr) override { mHighlight = ptr; }
-    virtual void DrawToDC(wxDC& dc) override;
-    virtual int Height() const override;
-    virtual int Width() const override;
-    virtual void OnClick(wxPoint const&) override;
+    auto GetDrawCommands(wxDC& dc) -> std::vector<CalChart::DrawCommand> override;
+    auto Height() const -> int override;
+    auto Width() const -> int override;
+    void OnClick(wxDC& dc, wxPoint const&) override;
 
     static int GetHeight(CalChartConfiguration const&);
 

--- a/src/ContinuityBrowserPanel.cpp
+++ b/src/ContinuityBrowserPanel.cpp
@@ -170,5 +170,5 @@ void ContinuityBrowserPanel::DoSetFocus(wxFocusEvent&)
 
 void ContinuityBrowserPanel::DoKillFocus(wxFocusEvent&)
 {
-    SetSelection(-1);
+    SetSelection({});
 }

--- a/src/CustomListViewPanel.cpp
+++ b/src/CustomListViewPanel.cpp
@@ -19,12 +19,158 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#define _LIBCPP_ENABLE_EXPERIMENTAL 1
 #include "CustomListViewPanel.h"
 #include "CalChartConfiguration.h"
-#include "basic_ui.h"
+#include "CalChartDrawPrimativesHelper.h"
+#include "CalChartDrawing.h"
+#include "CalChartRanges.h"
+#include <numeric>
 #include <wx/dcbuffer.h>
 
-#include <numeric>
+namespace {
+
+auto PrepareToDraw(wxDC& dc)
+{
+    dc.SetBackgroundMode(wxTRANSPARENT);
+    dc.Clear();
+}
+
+auto CreateCellLines(std::vector<int> const& whereToDraw) -> std::vector<CalChart::DrawCommand>
+{
+    if (whereToDraw.empty()) {
+        return {};
+    }
+
+    auto drawCmds = std::vector{
+        CalChart::Draw::withBrush(
+            wxCalChart::toBrush(*wxLIGHT_GREY_BRUSH),
+            CalChart::Draw::withPen(
+                wxCalChart::toPen(*wxBLACK),
+                CalChart::Draw::Rectangle(CalChart::Coord(0, 0), CalChart::Coord(0x7FFF, whereToDraw.back()))))
+    };
+    // TODO:  use std::views::drop_last when available (see https://stackoverflow.com/questions/71689137/what-is-the-best-way-to-drop-last-element-using-c20-ranges)
+    CalChart::append(drawCmds,
+        whereToDraw | std::views::take(whereToDraw.size() - 1) | std::views::transform([](auto where_y) {
+            return CalChart::Draw::Line(0, where_y, 0x7FFF, where_y);
+        }));
+    return drawCmds;
+}
+
+auto DrawNonSelected(wxDC& dc, std::vector<std::unique_ptr<DrawableCell>> const& cells, wxPoint lastLocation, std::optional<size_t> selected, bool dragging) -> std::vector<CalChart::DrawCommand>
+{
+    // first generate the heights:
+    auto heights = CalChart::Ranges::ToVector<int>(cells | std::views::transform([](auto&& cell) { return cell->Height(); }));
+    auto exScanHeights = std::vector<int>{};
+    std::exclusive_scan(heights.begin(), heights.end(), std::back_inserter(exScanHeights), 0);
+    auto inScanHeights = std::vector<int>{};
+    std::inclusive_scan(heights.begin(), heights.end(), std::back_inserter(inScanHeights));
+    auto where = std::distance(inScanHeights.begin(), std::lower_bound(inScanHeights.begin(), inScanHeights.end(), lastLocation.y));
+
+    auto drawCmds = CreateCellLines(inScanHeights);
+
+    // do something special for selected; find out it's height;
+    auto selected_height = selected ? cells.at(*selected)->Height() : 0;
+    // create a series of bitmaps, and draw them one at a time
+
+    // When drawing, you have to modify the placement of the Heights.  If we are dragging "upwards",
+    // then the cells "below" the selected cell's last location need to move downwards.  This is done
+    // by adding the height of the selected cell.  So if this inclusive scan of the heights before:
+    // ┌──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┐
+    // │  30  │  60  │  90  │ 120  │ 150  │ 180  │ 210  │ 240  │
+    // └──────┴──────┴──────┴──────┴──────┴──────┴──────┴──────┘
+    //            ▲             ▲
+    //            │             │
+    //     lastLocation      selected
+    // Then what we would do is add the selected height to the last location up to the selcted location:
+    // ┌──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┐
+    // │  30  │  90  │ 120  │ 120  │ 150  │ 180  │ 210  │ 240  │
+    // └──────┴──────┴──────┴──────┴──────┴──────┴──────┴──────┘
+    //            ▲             ▲
+    //            │             │
+    //     lastLocation      selected
+    // If the dragging "downwards", then the cells above selected cell's last location needs to be moved
+    // upwards, subtracting the selected height from the cells between the selection and including the last
+    // location.  So if this is before:
+    // ┌──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┐
+    // │  30  │  60  │  90  │ 120  │ 150  │ 180  │ 210  │ 240  │
+    // └──────┴──────┴──────┴──────┴──────┴──────┴──────┴──────┘
+    //                          ▲                    ▲
+    //                          │                    │
+    //                       selected         lastLocation
+    // Then afterwards:
+    // ┌──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┐
+    // │  30  │  60  │  90  │ 120  │ 120  │ 150  │ 180  │ 240  │
+    // └──────┴──────┴──────┴──────┴──────┴──────┴──────┴──────┘
+    //                          ▲                    ▲
+    //                          │                    │
+    //                       selected         lastLocation
+    // Note: because this includes the last location, we have to take care when we may run off the end
+    // of the array.
+    if (selected && dragging) {
+        auto select = static_cast<int>(*selected);
+        if (where < select) {
+            std::transform(exScanHeights.begin() + where, exScanHeights.begin() + select, exScanHeights.begin() + where, [selected_height](auto num) { return num + selected_height; });
+        } else if (where > select) {
+            auto which = static_cast<size_t>(where) == cells.size() ? where - 1 : where;
+            std::transform(exScanHeights.begin() + select + 1, exScanHeights.begin() + which + 1, exScanHeights.begin() + select + 1, [selected_height](auto num) { return num - selected_height; });
+        }
+    }
+
+    CalChart::append(drawCmds,
+        CalChart::Ranges::ToVector<CalChart::DrawCommand>(std::views::iota(0UL, cells.size())
+            | std::views::filter([selected](auto which) { return selected != which; })
+            | std::views::transform([&dc, &cells, exScanHeights](auto which) {
+                  return cells.at(which)->GetDrawCommands(dc) + CalChart::Coord(0, exScanHeights.at(which));
+              })
+            | std::views::join));
+    return drawCmds;
+}
+
+auto DrawSelected(wxDC& dc, std::vector<std::unique_ptr<DrawableCell>> const& cells, wxPoint firstPress, wxPoint lastLocation, std::optional<size_t> selected) -> std::vector<CalChart::DrawCommand>
+{
+    if (!selected) {
+        return {};
+    }
+    // We figure out where the dragging selected cell would be drawn.  First find out where
+    // the basis of the cell would have been using exclusive scan up to and including the selected cell.
+    // Then add the offset which would be the delta between the first press and last location.  So:
+    // ┌──────┬──────┬──────┬──────┬──────┬──────┬──────┬──────┐
+    // │  30  │  30  │  30  │  30  │  30  │  30  │  30  │  30  │
+    // └──────┴──────┴──────┴──────┴──────┴──────┴──────┴──────┘
+    //           ▲              ▲
+    //           │              │
+    //    lastLocation       selected
+    // Becomes:
+    // ┌──────┬──────┬──────┬──────┐
+    // │  0   │  30  │  60  │  90  │
+    // └──────┴──────┴──────┴──────┘
+    //           ▲              ▲
+    //           │              │
+    //    lastLocation       selected
+    // or 90 + (firstPress - lastLocation) = 90 - 60 = 30
+    auto heights = CalChart::Ranges::ToVector<int>(cells | std::views::take(*selected + 1) | std::views::transform([](auto&& cell) { return cell->Height(); }));
+    auto exScanHeights = std::vector<int>{};
+    std::exclusive_scan(heights.begin(), heights.end(), std::back_inserter(exScanHeights), 0);
+    auto whereToDraw = exScanHeights.back() + (lastLocation.y - firstPress.y);
+    auto height = cells.at(*selected)->Height();
+
+    auto drawCmds = std::vector{
+        CalChart::Draw::withBrush(
+            CalChart::Brush{ wxCalChart::toColor(wxColour{ "GREY" }) },
+            CalChart::Draw::Rectangle(CalChart::Coord{}, CalChart::Coord(0x7FFF, height)))
+    };
+    CalChart::append(drawCmds, cells.at(*selected)->GetDrawCommands(dc));
+    return drawCmds + CalChart::Coord(0, whereToDraw);
+}
+
+auto CreateListViewDrawCommands(wxDC& dc, std::vector<std::unique_ptr<DrawableCell>> const& cells, wxPoint firstPress, wxPoint lastLocation, std::optional<size_t> selected, bool dragging, wxPoint offset) -> std::vector<CalChart::DrawCommand>
+{
+    auto drawCmds = DrawNonSelected(dc, cells, lastLocation, selected, dragging);
+    CalChart::append(drawCmds, DrawSelected(dc, cells, firstPress, lastLocation, selected));
+    return drawCmds + CalChart::Coord(-offset.x, -offset.y);
+}
+}
 
 BEGIN_EVENT_TABLE(CustomListViewPanel, CustomListViewPanel::super)
 EVT_PAINT(CustomListViewPanel::OnPaint)
@@ -39,7 +185,6 @@ END_EVENT_TABLE()
 // Define a constructor for field canvas
 CustomListViewPanel::CustomListViewPanel(wxWindow* parent, wxWindowID winid, wxPoint const& pos, wxSize const& size, long style, wxString const& name)
     : super(parent, winid, pos, size, style, name)
-    , m_selected(-1)
     , m_dragging(false)
 {
 }
@@ -73,69 +218,22 @@ void CustomListViewPanel::OnPaint(wxPaintEvent&)
 {
     wxBufferedPaintDC dc(this);
     PrepareDC(dc);
-    dc.SetBackgroundMode(wxTRANSPARENT);
-    dc.SetBackground(*wxLIGHT_GREY_BRUSH);
-    dc.SetBrush(*wxWHITE_BRUSH);
-    dc.SetPen(*wxBLACK_PEN);
-    dc.Clear();
-    // do something special for selected; find out it's height;
-    auto selected_height = (m_selected < mCells.size()) ? mCells.at(m_selected)->Height() : 0;
-    // create a series of bitmaps, and draw them one at a time
+    PrepareToDraw(dc);
     auto offset = GetViewStart();
-    auto x_start = -offset.x;
-    auto y_start = -offset.y;
-    // draw the non-selected first;
-    for (auto i = 0u; i < mCells.size(); ++i) {
-        dc.DrawLine(x_start, y_start, x_start + 0xFFFF, y_start);
-        if (m_selected == i) {
-            if (!m_dragging || (m_lastLocation.y >= y_start && m_lastLocation.y < (y_start + selected_height))) {
-                y_start += selected_height;
-            }
-            continue;
-        }
-        if ((m_selected < mCells.size()) && m_dragging && (m_lastLocation.y >= y_start && m_lastLocation.y < (y_start + selected_height))) {
-            // make a hole for the thing
-            y_start += selected_height;
-        }
-        dc.SetDeviceOrigin(x_start, y_start);
-        mCells.at(i)->DrawToDC(dc);
-        dc.SetDeviceOrigin(0, 0);
-        y_start += mCells.at(i)->Height();
-    }
-    dc.DrawLine(x_start, y_start, x_start + 0xFFFF, y_start);
-
-    // draw the selected now
-    x_start = -offset.x;
-    y_start = -offset.y;
-    for (auto i = 0u; (m_selected < mCells.size()) && i < mCells.size(); ++i) {
-        if (i != m_selected) {
-            y_start += mCells.at(i)->Height();
-            continue;
-        }
-        auto&& current_brush = dc.GetBrush();
-        dc.SetBrush(wxBrush(wxT("GREY")));
-        auto y_delta = m_lastLocation.y - m_firstPress.y;
-        auto height = mCells.at(i)->Height();
-        dc.DrawRectangle(x_start, y_start + y_delta, 0xFFFF, height);
-        dc.SetBrush(current_brush);
-        dc.SetDeviceOrigin(x_start, y_start + y_delta);
-        mCells.at(i)->DrawToDC(dc);
-        dc.SetDeviceOrigin(0, 0);
-        y_start += height;
-    }
+    CalChartDraw::DrawCC_DrawCommandList(dc, CreateListViewDrawCommands(dc, mCells, m_firstPress, m_lastLocation, m_selected, m_dragging, offset));
 }
 
-size_t CustomListViewPanel::WhichCell(wxPoint const& point) const
+auto CustomListViewPanel::WhichCell(wxPoint const& point) const -> std::optional<size_t>
 {
     auto y_start = 0;
     auto which_cell = 0ul;
     for (; which_cell < mCells.size(); ++which_cell) {
         if ((point.y >= y_start) && (point.y < (y_start + mCells.at(which_cell)->Height()))) {
-            break;
+            return which_cell;
         }
         y_start += mCells.at(which_cell)->Height();
     }
-    return which_cell;
+    return {};
 }
 
 int CustomListViewPanel::HeightToCell(int which) const
@@ -158,10 +256,10 @@ void CustomListViewPanel::OnLeftDownMouseEvent(wxMouseEvent& event)
     auto which_cell = WhichCell(m_firstPress);
     m_selected = which_cell;
     m_dragging = true;
-    if (which_cell < mCells.size()) {
+    if (which_cell) {
         auto mouse_click = m_firstPress;
-        mouse_click.y -= HeightToCell(which_cell);
-        mCells.at(which_cell)->OnClick(mouse_click);
+        mouse_click.y -= HeightToCell(*which_cell);
+        mCells.at(*which_cell)->OnClick(dc, mouse_click);
     }
     Refresh();
 }
@@ -170,8 +268,8 @@ void CustomListViewPanel::OnLeftDoubleClick(wxMouseEvent& event)
 {
     // which cell would this be?
     auto which_cell = WhichCell(CalcUnscrolledPosition(event.GetPosition()));
-    if (which_cell < mCells.size()) {
-        OnEditEntry(which_cell);
+    if (which_cell) {
+        OnEditEntry(*which_cell);
     }
     Refresh();
 }
@@ -182,9 +280,9 @@ void CustomListViewPanel::OnLeftUpMouseEvent(wxMouseEvent& event)
     m_lastLocation = m_firstPress;
     // which cell would this be?
     auto which_cell = WhichCell(CalcUnscrolledPosition(event.GetPosition()));
-    if (starting_cell != which_cell) {
+    if (which_cell && starting_cell && *starting_cell != *which_cell) {
         // reorder.
-        OnMoveEntry(starting_cell, which_cell);
+        OnMoveEntry(*starting_cell, *which_cell);
     }
     m_selected = which_cell;
     m_dragging = false;
@@ -206,21 +304,22 @@ void CustomListViewPanel::OnChar(wxKeyEvent& event)
     // ignore keypresses if dragging:
     if (m_dragging)
         return;
-    if (event.GetKeyCode() == WXK_UP && m_selected < mCells.size() && m_selected > 0) {
-        --m_selected;
-    } else if (event.GetKeyCode() == WXK_DOWN && m_selected < (mCells.size() - 1)) {
-        ++m_selected;
+    if (event.GetKeyCode() == WXK_UP && m_selected < mCells.size() && m_selected && (*m_selected > 0)) {
+        --(*m_selected);
+    } else if (event.GetKeyCode() == WXK_DOWN && m_selected && (*m_selected < (mCells.size() - 1))) {
+        ++(*m_selected);
     } else if (event.GetKeyCode() == WXK_RETURN) {
         // with the shift key we go one above.
         // -1 means the end.
         // empty means 0 all the time
         //
+        auto where = m_selected ? *m_selected : 0;
         if (!event.ShiftDown()) {
-            ++m_selected;
+            ++where;
         }
-        OnNewEntry(std::min(mCells.size(), m_selected));
-    } else if (event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_NUMPAD_DELETE || event.GetKeyCode() == WXK_BACK) {
-        OnDeleteEntry(m_selected);
+        OnNewEntry(std::min(mCells.size(), where));
+    } else if (m_selected && (event.GetKeyCode() == WXK_DELETE || event.GetKeyCode() == WXK_NUMPAD_DELETE || event.GetKeyCode() == WXK_BACK)) {
+        OnDeleteEntry(*m_selected);
     } else {
         event.Skip();
     }

--- a/src/PreferencesShowModeSetup.cpp
+++ b/src/PreferencesShowModeSetup.cpp
@@ -29,7 +29,6 @@
 #include "CalChartShowMode.h"
 #include "CalChartSizes.h"
 #include "ColorSetupCanvas.h"
-#include "ContinuityBrowserPanel.h"
 #include "ModeSetupDialog.h"
 #include "PreferencesUtils.h"
 #include "ShowModeSetupCanvas.h"

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(
   CalChartMovePointsTool.h
   CalChartPoint.cpp
   CalChartPoint.h
+  CalChartRanges.h
   CalChartSelectTool.cpp
   CalChartSelectTool.h
   CalChartShapes.cpp

--- a/src/core/CalChartConstants.h
+++ b/src/core/CalChartConstants.h
@@ -95,9 +95,11 @@ enum class ContinuityCellColors {
     STEPTYPE,
     POINT,
     UNSET,
+    OUTLINE,
+    SELECTED,
     NUM,
 };
-using ContinuityCellColorsIterator = CalChart::Iterator<ContinuityCellColors, ContinuityCellColors::PROC, ContinuityCellColors::UNSET>;
+using ContinuityCellColorsIterator = CalChart::Iterator<ContinuityCellColors, ContinuityCellColors::PROC, ContinuityCellColors::SELECTED>;
 
 static const std::array<ColorInfoDefault_t, toUType(ContinuityCellColors::NUM)> ContCellColorInfoDefaults = {
     ColorInfoDefault_t{ "CONT CELL PROCEDURE", "LIME GREEN", 1 },
@@ -107,6 +109,8 @@ static const std::array<ColorInfoDefault_t, toUType(ContinuityCellColors::NUM)> 
     ColorInfoDefault_t{ "CONT CELL STEPTYPE", "SKY BLUE", 1 },
     ColorInfoDefault_t{ "CONT CELL POINT", "GOLD", 1 },
     ColorInfoDefault_t{ "CONT CELL UNSET", "WHITE", 1 },
+    ColorInfoDefault_t{ "CONT CELL OUTLINE", "BLACK", 1 },
+    ColorInfoDefault_t{ "CONT CELL SELECTED", "PINK", 3 },
 };
 
 enum class ShowModes {

--- a/src/core/CalChartContinuityToken.h
+++ b/src/core/CalChartContinuityToken.h
@@ -149,6 +149,8 @@ enum class Type {
     steptype,
     point,
     unset,
+    outline,
+    selected,
 };
 
 class Token;

--- a/src/core/CalChartDrawPrimatives.h
+++ b/src/core/CalChartDrawPrimatives.h
@@ -63,6 +63,11 @@ struct Brush {
 
 struct Pen {
     Color color{};
+    enum class Style {
+        Solid,
+        ShortDash,
+    };
+    Style style = Pen::Style::Solid;
     int width = 1;
     friend auto operator==(Pen const&, Pen const&) -> bool = default;
 };
@@ -70,13 +75,14 @@ struct Pen {
 // for the cases where we share a color
 struct BrushAndPen {
     Color color{};
-    Brush::Style style = Brush::Style::Solid;
+    Brush::Style brushStyle = Brush::Style::Solid;
+    Pen::Style penStyle = Pen::Style::Solid;
     int width = 1;
     friend auto operator==(BrushAndPen const&, BrushAndPen const&) -> bool = default;
 };
 
-inline auto toBrush(BrushAndPen b) { return Brush{ b.color, b.style }; }
-inline auto toPen(BrushAndPen b) { return Pen{ b.color, b.width }; }
+inline auto toBrush(BrushAndPen b) { return Brush{ b.color, b.brushStyle }; }
+inline auto toPen(BrushAndPen b) { return Pen{ b.color, b.penStyle, b.width }; }
 
 struct Font {
     enum class Family {

--- a/src/core/CalChartPoint.cpp
+++ b/src/core/CalChartPoint.cpp
@@ -233,8 +233,7 @@ namespace {
 
 auto Point::GetDrawCommands(unsigned ref, std::string const& label, double dotRatio, double pLineRatio, double sLineRatio) const -> std::vector<CalChart::DrawCommand>
 {
-    return toDrawCommands(CreatePoint(*this, GetSymbol(), label, dotRatio, pLineRatio, sLineRatio)
-        + GetPos(ref));
+    return CreatePoint(*this, GetSymbol(), label, dotRatio, pLineRatio, sLineRatio) + GetPos(ref);
 }
 
 // Test Suite stuff

--- a/src/core/CalChartRanges.h
+++ b/src/core/CalChartRanges.h
@@ -1,0 +1,131 @@
+#pragma once
+/*
+ * CalChartRanges.h
+ * Utilities for ranges
+ */
+
+/*
+   Copyright (C) 1995-2012  Garrick Brian Meeker, Richard Michael Powell
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <algorithm>
+#include <ranges>
+#include <stdexcept>
+
+namespace CalChart::Ranges {
+
+template <typename T, std::ranges::range Range>
+    requires std::convertible_to<std::ranges::range_value_t<Range>, T>
+inline auto ToVector(Range&& range) -> std::vector<T>
+{
+    auto result = std::vector<T>{};
+    std::ranges::copy(range, std::back_inserter(result));
+    return result;
+}
+
+// Basic zip_view implementation
+template <typename... Ranges>
+    requires(std::ranges::viewable_range<Ranges> && ...)
+class BasicZipView {
+public:
+    BasicZipView(Ranges&&... ranges)
+        : ranges_{ std::forward<Ranges>(ranges)... }
+    {
+    }
+
+    // Iterator type
+    class iterator {
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::tuple<typename std::ranges::range_value_t<Ranges>...>;
+        explicit iterator(typename std::pair<std::ranges::iterator_t<Ranges>, std::ranges::iterator_t<Ranges>>... iters)
+            : iters_{ iters... }
+        {
+        }
+        explicit iterator()
+            : iters_{}
+        {
+        }
+
+        // Increment operators
+        iterator& operator++()
+        {
+            std::apply([](auto&... iters) { (++std::get<0>(iters), ...); }, iters_);
+            // if any of the iterators matches the end iterators, we are at the end, so bump them all to the end.
+            if (std::apply([](auto&... iters) { return ((std::get<0>(iters) == std::get<1>(iters)) || ...); }, iters_)) {
+                std::apply([](auto&... iters) { ((std::get<0>(iters) = std::get<1>(iters)), ...); }, iters_);
+            }
+            return *this;
+        }
+
+        iterator operator++(int)
+        {
+            iterator tmp(*this);
+            ++(*this);
+            return tmp;
+        }
+
+        // Dereference operator
+        auto operator*() const
+        {
+            return std::apply([](auto&&... iters) {
+                return std::tuple{ *std::get<0>(iters)... };
+            },
+                iters_);
+        }
+
+        // Equality comparison operator
+        bool operator==(const iterator& other) const
+        {
+            return iters_ == other.iters_;
+        }
+
+        bool operator!=(const iterator& other) const
+        {
+            return !(*this == other);
+        }
+
+    private:
+        std::tuple<typename std::pair<std::ranges::iterator_t<Ranges>, std::ranges::iterator_t<Ranges>>...> iters_;
+    };
+
+    iterator begin()
+    {
+        return std::apply([](auto&&... r) {
+            return iterator(std::pair{ std::ranges::begin(r), std::ranges::end(r) }...);
+        },
+            ranges_);
+    }
+
+    iterator end()
+    {
+        return std::apply([](auto&&... r) {
+            return iterator(std::pair{ std::ranges::end(r), std::ranges::end(r) }...);
+        },
+            ranges_);
+    }
+
+private:
+    std::tuple<Ranges...> ranges_;
+};
+
+template <typename... Ranges>
+BasicZipView<Ranges...> zip_view(Ranges&&... ranges)
+{
+    return BasicZipView<Ranges...>(std::forward<Ranges>(ranges)...);
+}
+
+}

--- a/tests/CalChartDrawCommandTests.cpp
+++ b/tests/CalChartDrawCommandTests.cpp
@@ -152,13 +152,13 @@ TEST_CASE("DrawCommand")
 
     SECTION("CreateOutline")
     {
-        auto cmds = CalChart::Draw::toDrawCommands(CalChart::Draw::Field::CreateOutline({ 16, 5 }) + CalChart::Coord{ 1, 2 });
+        auto cmds = CalChart::Draw::Field::CreateOutline({ 16, 5 }) + CalChart::Coord{ 1, 2 };
         TestCreateOutline(cmds);
     }
 
     SECTION("CreateVerticalSolidLine")
     {
-        auto cmds = CalChart::Draw::toDrawCommands(CalChart::Draw::Field::CreateVerticalSolidLine({ 16, 5 }, 1) + CalChart::Coord{ 1, 2 });
+        auto cmds = CalChart::Draw::Field::CreateVerticalSolidLine({ 16, 5 }, 1) + CalChart::Coord{ 1, 2 };
         CHECK(cmds.size() == 3);
         auto uut = std::get<CalChart::Draw::Line>(cmds[0]);
         CHECK(uut.c1 == CalChart::Coord{ 1, 2 });
@@ -173,7 +173,7 @@ TEST_CASE("DrawCommand")
 
     SECTION("CreateVerticalDottedLine")
     {
-        auto cmds = CalChart::Draw::toDrawCommands(CalChart::Draw::Field::CreateVerticalDottedLine({ 16, 5 }, 1) + CalChart::Coord{ 1, 2 });
+        auto cmds = CalChart::Draw::Field::CreateVerticalDottedLine({ 16, 5 }, 1) + CalChart::Coord{ 1, 2 };
         CHECK(cmds.size() == 6);
         auto uut = std::get<CalChart::Draw::Line>(cmds[0]);
         CHECK(uut.c1 == CalChart::Coord{ 5, 2 });
@@ -196,7 +196,7 @@ TEST_CASE("DrawCommand")
     }
     SECTION("CreateHorizontalDottedLine")
     {
-        auto cmds = CalChart::Draw::toDrawCommands(CalChart::Draw::Field::CreateHorizontalDottedLine({ CalChart::Int2CoordUnits(5), CalChart::Int2CoordUnits(20) }, 8, 12, CalChart::Int2CoordUnits(1)) + CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(2) });
+        auto cmds = CalChart::Draw::Field::CreateHorizontalDottedLine({ CalChart::Int2CoordUnits(5), CalChart::Int2CoordUnits(20) }, 8, 12, CalChart::Int2CoordUnits(1)) + CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(2) };
         CHECK(cmds.size() == 6);
         auto uut = std::get<CalChart::Draw::Line>(cmds[0]);
         CHECK(uut.c1 == CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(6) });
@@ -219,7 +219,7 @@ TEST_CASE("DrawCommand")
     }
     SECTION("CreateHashes")
     {
-        auto cmds = CalChart::Draw::toDrawCommands(CalChart::Draw::Field::CreateHashes({ CalChart::Int2CoordUnits(5), CalChart::Int2CoordUnits(20) }, 8, 12, CalChart::Int2CoordUnits(1)) + CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(2) });
+        auto cmds = CalChart::Draw::Field::CreateHashes({ CalChart::Int2CoordUnits(5), CalChart::Int2CoordUnits(20) }, 8, 12, CalChart::Int2CoordUnits(1)) + CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(2) };
         CHECK(cmds.size() == 4);
         auto uut = std::get<CalChart::Draw::Line>(cmds[0]);
         CHECK(uut.c1 == CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(10) });
@@ -236,7 +236,7 @@ TEST_CASE("DrawCommand")
     }
     SECTION("CreateHashTicks")
     {
-        auto cmds = CalChart::Draw::toDrawCommands(CalChart::Draw::Field::CreateHashTicks({ CalChart::Int2CoordUnits(5), CalChart::Int2CoordUnits(20) }, 8, 12, CalChart::Int2CoordUnits(1)) + CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(2) });
+        auto cmds = CalChart::Draw::Field::CreateHashTicks({ CalChart::Int2CoordUnits(5), CalChart::Int2CoordUnits(20) }, 8, 12, CalChart::Int2CoordUnits(1)) + CalChart::Coord{ CalChart::Int2CoordUnits(1), CalChart::Int2CoordUnits(2) };
         CHECK(cmds.size() == 8);
         auto uut = std::get<CalChart::Draw::Line>(cmds[0]);
         CHECK(uut.c1 == CalChart::Coord{ CalChart::Float2CoordUnits(2.6), CalChart::Float2CoordUnits(10) });
@@ -268,7 +268,7 @@ TEST_CASE("DrawCommand")
         using namespace std::string_literals;
         using TextAnchor = CalChart::Draw::Text::TextAnchor;
         auto testData = std::vector{ "A"s, "B"s, "C"s };
-        auto cmds = CalChart::Draw::toDrawCommands(CalChart::Draw::Field::CreateYardlineLabels(testData, { CalChart::Int2CoordUnits(14), 5 }, 2, 1) + CalChart::Coord{ 3, 5 });
+        auto cmds = CalChart::Draw::Field::CreateYardlineLabels(testData, { CalChart::Int2CoordUnits(14), 5 }, 2, 1) + CalChart::Coord{ 3, 5 };
         CHECK(cmds.size() == 4);
 
         auto uut = std::get<CalChart::Draw::Text>(cmds[0]);

--- a/tests/CalChartShapesTests.cpp
+++ b/tests/CalChartShapesTests.cpp
@@ -12,12 +12,12 @@ TEST_CASE("CalChartShapeTests", "Shape_crosshairs")
 {
     auto uut = CalChart::Shape_crosshairs({ 10, 10 }, 10);
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(20, 20, 40, 40),
               CalChart::Draw::Line(40, 20, 20, 40),
           });
     uut.OnMove({ 51, 53 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(60, 60, 80, 80),
               CalChart::Draw::Line(80, 60, 60, 80),
           });
@@ -28,16 +28,16 @@ TEST_CASE("Shape_line", "CalChartShapeTests")
     auto uut = CalChart::Shape_line(CalChart::Coord{ 10, 10 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
     CHECK(uut.GetPoint() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 30, 30),
           });
     uut.OnMove({ 51, 53 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 70, 70),
           });
     uut = CalChart::Shape_line(CalChart::Coord{ 10, 10 }, CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 70, 70),
           });
 }
@@ -47,18 +47,18 @@ TEST_CASE("Shape_x", "CalChartShapeTests")
     auto uut = CalChart::Shape_x(CalChart::Coord{ 10, 10 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
     CHECK(uut.GetPoint() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 30, 30),
               CalChart::Draw::Line(30, 30, 30, 30),
           });
     uut.OnMove({ 51, 53 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 70, 70),
               CalChart::Draw::Line(70, 30, 30, 70),
           });
     uut = CalChart::Shape_x(CalChart::Coord{ 10, 10 }, CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 70, 70),
               CalChart::Draw::Line(70, 30, 30, 70),
           });
@@ -69,18 +69,18 @@ TEST_CASE("Shape_cross", "CalChartShapeTests")
     auto uut = CalChart::Shape_cross(CalChart::Coord{ 10, 10 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
     CHECK(uut.GetPoint() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 30, 30),
               CalChart::Draw::Line(30, 30, 30, 30),
           });
     uut.OnMove({ 51, 53 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(50, 30, 50, 70),
               CalChart::Draw::Line(30, 50, 70, 50),
           });
     uut = CalChart::Shape_cross(CalChart::Coord{ 10, 10 }, CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(50, 30, 50, 70),
               CalChart::Draw::Line(30, 50, 70, 50),
           });
@@ -91,16 +91,16 @@ TEST_CASE("Shape_ellipse", "CalChartShapeTests")
     auto uut = CalChart::Shape_ellipse(CalChart::Coord{ 10, 10 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
     CHECK(uut.GetPoint() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Ellipse(30, 30, 30, 30),
           });
     uut.OnMove({ 51, 53 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Ellipse(30, 30, 70, 70),
           });
     uut = CalChart::Shape_ellipse(CalChart::Coord{ 10, 10 }, CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Ellipse(30, 30, 70, 70),
           });
 }
@@ -110,22 +110,22 @@ TEST_CASE("Shape_angline", "CalChartShapeTests")
     auto uut = CalChart::Shape_angline(CalChart::Coord{ 10, 10 }, CalChart::Coord{ 10, 10 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
     CHECK(uut.GetPoint() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 30, 30),
           });
     uut.OnMove({ 51, 53 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 49, 49 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 69, 69),
           });
     uut.OnMove({ 51, 100 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 74, 74 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 94, 94),
           });
     uut.OnMove({ 51, 0 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 24, 24 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 44, 44),
           });
 }
@@ -134,15 +134,15 @@ TEST_CASE("Shape_arc", "CalChartShapeTests")
 {
     auto uut = CalChart::Shape_arc(CalChart::Coord{ 10, 10 }, CalChart::Coord{ 20, 20 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(40, 39, 40, 39, 30, 30),
           });
     uut.OnMove({ 51, 53 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(40, 39, 40, 39, 30, 30),
           });
     uut.OnMove({ 51, 100 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(35, 42, 40, 39, 30, 30),
           });
 }
@@ -151,16 +151,16 @@ TEST_CASE("Shape_arc2", "CalChartShapeTests")
 {
     auto uut = CalChart::Shape_arc(CalChart::Coord{ 20, 20 }, CalChart::Coord{ 10, 10 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 20, 20 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(30, 31, 30, 31, 40, 40),
           });
     uut.OnMove({ 51, 53 }, trucate);
-    auto peek = CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    auto peek = uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 };
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(50, 49, 30, 31, 40, 40),
           });
     uut.OnMove({ 51, 100 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(30, 31, 44, 53, 40, 40),
           });
 }
@@ -170,7 +170,7 @@ TEST_CASE("Shape_arcquad0", "CalChartShapeTests")
     auto const center = CalChart::Coord{ 10, 10 };
     auto const p1 = CalChart::Coord{ 10, 20 };
     auto uut = CalChart::Shape_arc(center, p1);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand()) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand()) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(p1, p1, center),
           });
     for (auto&& i : std::vector{
@@ -180,7 +180,7 @@ TEST_CASE("Shape_arcquad0", "CalChartShapeTests")
              std::tuple{ CalChart::Coord{ 0, 0 }, CalChart::Draw::Arc{ { 3, 3 }, { 10, 20 }, center } },
          }) {
         uut.OnMove(std::get<0>(i), trucate);
-        CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand()) == std::vector<CalChart::DrawCommand>{ std::get<1>(i) });
+        CHECK(uut.GetCC_DrawCommand() == std::vector<CalChart::DrawCommand>{ std::get<1>(i) });
     }
 }
 
@@ -189,7 +189,7 @@ TEST_CASE("Shape_arcquad2", "CalChartShapeTests")
     auto const center = CalChart::Coord{ 10, 10 };
     auto const p1 = CalChart::Coord{ 20, 10 };
     auto uut = CalChart::Shape_arc(center, p1);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand()) == std::vector<CalChart::DrawCommand>{
+    CHECK(uut.GetCC_DrawCommand() == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Arc(p1, p1, center),
           });
     for (auto&& i : std::vector{
@@ -332,7 +332,7 @@ TEST_CASE("Shape_rect", "CalChartShapeTests")
     auto uut = CalChart::Shape_rect(CalChart::Coord{ 10, 10 });
     CHECK(uut.GetOrigin() == CalChart::Coord{ 10, 10 });
     CHECK(uut.GetPoint() == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 30, 30),
               CalChart::Draw::Line(30, 30, 30, 30),
               CalChart::Draw::Line(30, 30, 30, 30),
@@ -340,15 +340,15 @@ TEST_CASE("Shape_rect", "CalChartShapeTests")
           });
     uut.OnMove({ 51, 49 }, trucate);
     CHECK(uut.GetPoint() == CalChart::Coord{ 51, 49 });
-    auto result = CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    auto result = uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 };
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 71, 30),
               CalChart::Draw::Line(71, 30, 71, 69),
               CalChart::Draw::Line(71, 69, 30, 69),
               CalChart::Draw::Line(30, 69, 30, 30),
           });
     uut = CalChart::Shape_rect(CalChart::Coord{ 10, 10 }, CalChart::Coord{ 50, 50 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 70, 30),
               CalChart::Draw::Line(70, 30, 70, 70),
               CalChart::Draw::Line(70, 70, 30, 70),
@@ -360,20 +360,20 @@ TEST_CASE("Shape_lasso", "CalChartShapeTests")
 {
     auto uut = CalChart::Lasso(CalChart::Coord{ 10, 10 });
     CHECK(*(uut.FirstPoint()) == CalChart::Coord{ 10, 10 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }).empty());
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }).empty());
     uut.OnMove({ 51, 49 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 71, 69),
           });
     CHECK(abs(CalChart::GetDistance(uut.GetPolygon()) - 56.586216) < 0.0001);
     uut.Append({ 51, 49 });
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 71, 69),
               CalChart::Draw::Line(71, 69, 71, 69),
           });
     CHECK(abs(CalChart::GetDistance(uut.GetPolygon()) - 56.586216) < 0.0001);
     uut.OnMove({ 5, 6 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 71, 69),
               CalChart::Draw::Line(71, 69, 71, 69),
               CalChart::Draw::Line(71, 69, 25, 26),
@@ -387,12 +387,12 @@ TEST_CASE("Shape_Poly", "CalChartShapeTests")
     uut.OnMove({ 51, 49 }, trucate);
     uut.Append({ 51, 49 });
     uut.OnMove({ 5, 6 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 71, 69),
               CalChart::Draw::Line(71, 69, 25, 26),
           });
     uut.OnMove({ 5, 6 }, trucate);
-    CHECK(CalChart::Draw::toDrawCommands(uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
+    CHECK((uut.GetCC_DrawCommand() + CalChart::Coord{ 20, 20 }) == std::vector<CalChart::DrawCommand>{
               CalChart::Draw::Line(30, 30, 71, 69),
               CalChart::Draw::Line(71, 69, 25, 26),
           });

--- a/tests/CalChartShowModeTests.cpp
+++ b/tests/CalChartShowModeTests.cpp
@@ -24,7 +24,7 @@ static auto TestCreateOutline(auto cmds)
 TEST_CASE("Draw", "CalChartShowMode")
 {
     auto uut1 = CalChart::ShowMode::GetDefaultShowMode();
-    auto cmds = CalChart::Draw::toDrawCommands(CalChart::CreateFieldLayout(uut1, false) + CalChart::Coord{ 1, 2 });
+    auto cmds = CalChart::CreateFieldLayout(uut1, false) + CalChart::Coord{ 1, 2 };
     CHECK(cmds.size() == 105);
     TestCreateOutline(std::vector(cmds.begin(), cmds.begin() + 4));
 }


### PR DESCRIPTION
Issue #444: Continuity view on main frame looks wrong

De-fanging operator+ for DrawCommands by making it explicitly create a range.

This was caused by a problem with wxWidgets.  Updating to a branch of 3.2.4 with the fix.

Also using this as a moment to update the way we do drawing.  Using more of the CalChart::DrawCommand concept to be more portable.

Using ranges whenever possible.