### PR TITLE
Issue #467: Shows with Parse Continuity and references points are inc…

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Bugs addressed in this release:
 * [#404](../../issues/404) Crash when sheet has zero beats.
 * [#444](../../issues/444) Continuity view on main frame looks wrong
 * [#446](../../issues/446) Transition solver crashes
+* [#467](../../issues/467) Shows with Parse Continuity and references points are incorrect in 3.6
 
 Other changes:
 

--- a/src/core/contgram.y
+++ b/src/core/contgram.y
@@ -156,7 +156,7 @@ point
 	| rwNP
 		{ $$ = new CalChart::Cont::NextPoint(); }
 	| rwR FLOATCONST
-		{ $$ = new CalChart::Cont::RefPoint((unsigned)$2 - 1); }
+		{ $$ = new CalChart::Cont::RefPoint((unsigned)$2 - 0); }
 	;
 
 value


### PR DESCRIPTION
…orrect in 3.6

The reference point was not updated when the continuities have changed.