### PR TITLE
Issue #550: Make animation compilation an operation of two pairs of s…

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -30,4 +30,5 @@ Other changes:
 * [#538](../../issues/538) Remove unused cont symbol from animate errors
 * [#546](../../issues/546) Change behavior of show generation so endPosition and nextPosition in animation are the same
 * [#547](../../issues/547) Add some basic profiling to calband_cmd
+* [#550](../../issues/550) Make animation compilation an operation of two pairs of sheets
 

--- a/src/core/CalChartAnimation.h
+++ b/src/core/CalChartAnimation.h
@@ -82,7 +82,7 @@ public:
     [[nodiscard]] auto GetTotalNumberBeatsUpTo(int sheet) const -> beats_t { return mSheets.GetTotalNumberBeatsUpTo(sheet); }
     [[nodiscard]] auto GetTotalNumberBeats() const { return mSheets.TotalBeats(); }
 
-    [[nodiscard]] auto GetErrors() const { return mErrors; }
+    [[nodiscard]] auto GetErrors() const { return mSheets.GetAnimationErrors(); }
 
     // Sheet -> selection of marchers who collided
     [[nodiscard]] auto GetCollisions() const -> std::map<int, CalChart::SelectionList> { return mSheets.SheetsToMarchersWhoCollided(); }
@@ -104,9 +104,6 @@ public:
 private:
     // There are two types of data, the ones that are set when we are created, and the ones that modify over time.
     Animate::Sheets mSheets;
-
-    // mapping of Which, Sheet, Beat to a collision
-    std::vector<Animate::Errors> mErrors;
 };
 
 }

--- a/src/core/CalChartAnimationCompile.h
+++ b/src/core/CalChartAnimationCompile.h
@@ -54,8 +54,9 @@ namespace Cont {
 }
 
 namespace CalChart::Animate {
+using beats_t = unsigned;
 using Variables = std::array<std::map<unsigned, float>, Cont::kNumVariables>;
-using CompileResult = std::vector<Command>;
+using CompileResult = std::pair<std::vector<Command>, ErrorsEncountered>;
 
 // Compile a point into the Animation Commands
 // Variables and Errors are passed as references as they maintain state over all the compiles,
@@ -64,19 +65,22 @@ using CompileResult = std::vector<Command>;
 // end is the position to go that's the next valid animation -- the shee has at least 1 beat
 // next position is the position of the marcher on the next sheet, regardless of number of beats.
 // is optional because if there is no next sheet (this is the last sheet), then it's null.
+struct AnimationData {
+    unsigned whichMarcher;
+    Point marcherPosition;
+    std::vector<std::unique_ptr<Cont::Procedure>> const& continuity;
+    std::optional<Coord> endPosition;
+    beats_t numBeats;
+    bool isLastAnimationSheet;
+};
+
 auto CreateCompileResult(
-    Variables& variablesStates,
-    Errors& errors,
-    unsigned whichMarcher,
-    Point point,
-    beats_t beats,
-    bool isLastAnimationSheet,
-    std::optional<Coord> endPosition,
-    std::vector<std::unique_ptr<Cont::Procedure>> const& proc) -> CompileResult;
+    AnimationData const& animationData,
+    Variables& variablesStates) -> CompileResult;
 
 struct Compile {
     virtual ~Compile() = default;
-    virtual auto Append(Animate::Command cmd) -> bool = 0;
+    virtual auto Append(Command cmd) -> bool = 0;
     virtual void RegisterError(Error err) const = 0;
 
     [[nodiscard]] virtual auto GetVarValue(Cont::Variable varnum) const -> float = 0;

--- a/src/core/CalChartAnimationErrors.h
+++ b/src/core/CalChartAnimationErrors.h
@@ -81,11 +81,8 @@ static inline auto operator<<(std::ostream& os, Error e) -> std::ostream&
     return os << static_cast<int>(e);
 }
 
+using ErrorsEncountered = std::set<Error>;
 using Errors = std::map<Error, SelectionList>;
 inline auto AnyErrors(Errors const& errors) { return !errors.empty(); }
-inline auto RegisterError(Errors& errors, Error err, int curr_pt)
-{
-    errors[err].insert(curr_pt);
-}
 
 }

--- a/src/core/CalChartShow.h
+++ b/src/core/CalChartShow.h
@@ -51,6 +51,7 @@
 #include <map>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <ranges>
 #include <set>
 #include <string>
 #include <utility>
@@ -153,6 +154,16 @@ public:
     // Saving the show.
     [[nodiscard]] auto SerializeShow() const -> std::vector<std::byte>;
 
+    [[nodiscard]] auto AreSheetsInAnimation() const
+    {
+        return mSheets | std::views::transform([](auto&& sheet) { return sheet.IsInAnimation(); });
+    }
+
+    [[nodiscard]] auto SheetsInAnimation() const
+    {
+        return mSheets | std::views::filter([](auto&& sheet) { return sheet.IsInAnimation(); });
+    }
+
 private:
     // modification of show is private, and externally done through create and exeucte commands
     auto RemoveNthSheet(int sheetidx) -> Sheet_container_t;
@@ -166,13 +177,31 @@ private:
     void SetPointLabelAndInstrument(std::vector<std::pair<std::string, std::string>> const& labels);
 
     // Descriptions aren't used, but keeping this alive.  See issue #203
-    [[nodiscard]] auto GetDescr() const { return mDescr; }
-    void SetDescr(std::string const& newdescr) { mDescr = newdescr; }
+    [[nodiscard]] auto GetDescr() const
+    {
+        return mDescr;
+    }
+    void SetDescr(std::string const& newdescr)
+    {
+        mDescr = newdescr;
+    }
 
-    auto GetSheetBegin() { return mSheets.begin(); }
-    auto GetSheetEnd() { return mSheets.end(); }
-    auto GetNthSheet(unsigned n) { return GetSheetBegin() + n; }
-    auto GetCurrentSheet() { return GetNthSheet(mSheetNum); }
+    auto GetSheetBegin()
+    {
+        return mSheets.begin();
+    }
+    auto GetSheetEnd()
+    {
+        return mSheets.end();
+    }
+    auto GetNthSheet(unsigned n)
+    {
+        return GetSheetBegin() + n;
+    }
+    auto GetCurrentSheet()
+    {
+        return GetNthSheet(mSheetNum);
+    }
 
     void SetShowMode(ShowMode const&);
 

--- a/tests/CalChartAnimationSheetTests.cpp
+++ b/tests/CalChartAnimationSheetTests.cpp
@@ -9,14 +9,16 @@
 
 TEST_CASE("AnimationSheetTest", "Animate::Sheet")
 {
-    auto cont1 = std::vector<CalChart::Animate::Command>{
-        CalChart::Animate::CommandStill{ { 16, 16 }, 4, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
-        CalChart::Animate::CommandMove{ { 16, 16 }, 8, { 0, 128 } },
-        CalChart::Animate::CommandStill{ { 16, 144 }, 6, CalChart::Animate::CommandStill::Style::Close, CalChart::Degree::South() },
+    auto cont1 = CalChart::Animate::CompileResult{
+        { CalChart::Animate::CommandStill{ { 16, 16 }, 4, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+            CalChart::Animate::CommandMove{ { 16, 16 }, 8, { 0, 128 } },
+            CalChart::Animate::CommandStill{ { 16, 144 }, 6, CalChart::Animate::CommandStill::Style::Close, CalChart::Degree::South() } },
+        {}
     };
-    auto cont2 = std::vector<CalChart::Animate::Command>{
-        CalChart::Animate::CommandMove{ { 16, 144 }, 8, { 0, -128 } },
-        CalChart::Animate::CommandStill{ { 16, 16 }, 8, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+    auto cont2 = CalChart::Animate::CompileResult{
+        { CalChart::Animate::CommandMove{ { 16, 144 }, 8, { 0, -128 } },
+            CalChart::Animate::CommandStill{ { 16, 16 }, 8, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() } },
+        {}
     };
     auto uut = CalChart::Animate::Sheet{ "test", 16, { cont1, cont2 } };
     CHECK("test" == uut.GetName());
@@ -38,14 +40,20 @@ TEST_CASE("AnimationSheetTest", "Animate::Sheet")
 TEST_CASE("NoCollision", "Animate::Sheet")
 {
     std::cout << "doing test nocolsion\n";
-    auto cont1 = std::vector<CalChart::Animate::Command>{
-        CalChart::Animate::CommandStill{ { 64, 16 }, 4, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
-        CalChart::Animate::CommandMove{ { 64, 16 }, 8, { 0, 128 } },
-        CalChart::Animate::CommandStill{ { 64, 144 }, 6, CalChart::Animate::CommandStill::Style::Close, CalChart::Degree::South() },
+    auto cont1 = CalChart::Animate::CompileResult{
+        {
+            CalChart::Animate::CommandStill{ { 64, 16 }, 4, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+            CalChart::Animate::CommandMove{ { 64, 16 }, 8, { 0, 128 } },
+            CalChart::Animate::CommandStill{ { 64, 144 }, 6, CalChart::Animate::CommandStill::Style::Close, CalChart::Degree::South() },
+        },
+        {}
     };
-    auto cont2 = std::vector<CalChart::Animate::Command>{
-        CalChart::Animate::CommandMove{ { 16, 144 }, 8, { 0, -128 } },
-        CalChart::Animate::CommandStill{ { 16, 16 }, 8, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+    auto cont2 = CalChart::Animate::CompileResult{
+        {
+            CalChart::Animate::CommandMove{ { 16, 144 }, 8, { 0, -128 } },
+            CalChart::Animate::CommandStill{ { 16, 16 }, 8, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+        },
+        {}
     };
     auto uut = CalChart::Animate::Sheet{ "test", 16, { cont1, cont2 } };
     CHECK(uut.GetAllBeatsWithCollisions().empty());
@@ -54,14 +62,20 @@ TEST_CASE("NoCollision", "Animate::Sheet")
 TEST_CASE("Animate::Sheets", "Animate::Sheets")
 {
     using beats_t = CalChart::Animate::beats_t;
-    auto cont1 = std::vector<CalChart::Animate::Command>{
-        CalChart::Animate::CommandStill{ { 64, 16 }, 4, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
-        CalChart::Animate::CommandMove{ { 64, 16 }, 8, { 0, 128 } },
-        CalChart::Animate::CommandStill{ { 64, 144 }, 6, CalChart::Animate::CommandStill::Style::Close, CalChart::Degree::South() },
+    auto cont1 = CalChart::Animate::CompileResult{
+        {
+            CalChart::Animate::CommandStill{ { 64, 16 }, 4, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+            CalChart::Animate::CommandMove{ { 64, 16 }, 8, { 0, 128 } },
+            CalChart::Animate::CommandStill{ { 64, 144 }, 6, CalChart::Animate::CommandStill::Style::Close, CalChart::Degree::South() },
+        },
+        {}
     };
-    auto cont2 = std::vector<CalChart::Animate::Command>{
-        CalChart::Animate::CommandMove{ { 16, 144 }, 8, { 0, -128 } },
-        CalChart::Animate::CommandStill{ { 16, 16 }, 2, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+    auto cont2 = CalChart::Animate::CompileResult{
+        {
+            CalChart::Animate::CommandMove{ { 16, 144 }, 8, { 0, -128 } },
+            CalChart::Animate::CommandStill{ { 16, 16 }, 2, CalChart::Animate::CommandStill::Style::MarkTime, CalChart::Degree::North() },
+        },
+        {}
     };
     auto sheet1 = CalChart::Animate::Sheet{ "test", 16, { cont1 } };
     auto sheet2 = CalChart::Animate::Sheet{ "test2", 10, { cont2 } };

--- a/tests/CalChartContinuityTokenTests.cpp
+++ b/tests/CalChartContinuityTokenTests.cpp
@@ -32,17 +32,16 @@ template <typename Sheets, typename Conts>
 auto GetCompiledResults(Sheets const& sheets, Conts const& proc)
 {
     Animate::Variables vars{};
-    Animate::Errors errors{};
-
-    return Animate::CreateCompileResult(
-        vars,
-        errors,
+    auto animationData = Animate::AnimationData{
         0,
         sheets.begin()->GetPoint(0),
-        sheets.begin()->GetBeats(),
-        true,
+        proc,
         (sheets.begin() + 1)->GetPoint(0).GetPos(),
-        proc);
+        sheets.begin()->GetBeats(),
+        true
+    };
+
+    return Animate::CreateCompileResult(animationData, vars);
 }
 
 auto CreateSheetsForTest(Coord begin, Coord end, int beats)
@@ -86,7 +85,7 @@ TEST_CASE("Fountain", "CalChartContinuityToken")
     auto procs = std::vector<std::unique_ptr<Cont::Procedure>>{};
     procs.push_back(std::move(uut));
     auto sheets = CreateSheetsForTest({ 0, 0 }, { 8, 16 }, 14);
-    auto compiledResults = GetCompiledResults(sheets, procs);
+    auto [compiledResults, errors] = GetCompiledResults(sheets, procs);
 
     auto goldCompile = std::vector<Animate::Command>{
         Animate::CommandMove{ Coord{ 0, 0 }, 6, Coord{ 128, 128 } },
@@ -107,7 +106,7 @@ TEST_CASE("Fountain with nulls", "CalChartContinuityToken")
     auto procs = std::vector<std::unique_ptr<Cont::Procedure>>{};
     procs.push_back(std::move(uut));
     auto sheets = CreateSheetsForTest({ 0, 0 }, { 8, 16 }, 16);
-    auto compiledResults = GetCompiledResults(sheets, procs);
+    auto [compiledResults, errors] = GetCompiledResults(sheets, procs);
 
     auto goldCompile = std::vector<Animate::Command>{
         Animate::CommandMove{ Coord{ 0, 0 }, 8, Coord{ 128, 128 } },
@@ -129,7 +128,7 @@ TEST_CASE("HSCM", "CalChartContinuityToken")
     auto procs = std::vector<std::unique_ptr<Cont::Procedure>>{};
     procs.push_back(std::move(uut));
     auto sheets = CreateSheetsForTest({ 0, 0 }, { -8, 0 }, { 8, -2 }, { 0, 0 }, 40);
-    auto compiledResults = GetCompiledResults(sheets, procs);
+    auto [compiledResults, errors] = GetCompiledResults(sheets, procs);
 
     auto goldCompile = std::vector<Animate::Command>{
         Animate::CommandMove{ Coord{ 0, 0 }, 9, Coord{ -16 * 9, 0 } },
@@ -153,7 +152,7 @@ TEST_CASE("DMCM", "CalChartContinuityToken")
     auto procs = std::vector<std::unique_ptr<Cont::Procedure>>{};
     procs.push_back(std::move(uut));
     auto sheets = CreateSheetsForTest({ 0, 0 }, { -8, 8 }, { 8, -10 }, { 0, 0 }, 40);
-    auto compiledResults = GetCompiledResults(sheets, procs);
+    auto [compiledResults, errors] = GetCompiledResults(sheets, procs);
 
     auto goldCompile = std::vector<Animate::Command>{
         Animate::CommandMove{ Coord{ 0, 0 }, 9, Coord{ -16 * 9, 16 * 9 } },


### PR DESCRIPTION
…heets

Redoing the way we do animations.
Moving from iterating over symbols to iterating over marchers. Using ranges to allow composition instead of iterations. Breaking getAnimationResult into its own function. Combining the creation of Commands and Errors as part of the sheet compilation.