### PR TITLE
Issue #584: Why didn't the failures in ASAN cause sanity_test.py to fail

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -6,3 +6,6 @@ Bugs addressed in this release:
 
 Other changes:
 
+* [#584](../../issues/584) Why didn't the failures in ASAN cause sanity_test.py to fail?
+
+

--- a/tests/sanity_tester.py
+++ b/tests/sanity_tester.py
@@ -58,6 +58,11 @@ def compare_files(file1, file2, custom_comparison_function):
     num_errors = 0
     line_num = 0
     with open(file1, 'r') as f1, open(file2, 'r') as f2:
+        line_count1 = sum(1 for line in f1)
+        line_count2 = sum(1 for line in f2)
+        if (line_count1 != line_count2):
+            print(f"Failed.  Lines {file1}: {line_count1}, {file2}: {line_count2}")
+            return 1
         for line1, line2 in zip(f1, f2):
             line_num = line_num + 1
             # Apply custom comparison function to each line


### PR DESCRIPTION
Looks like using zip to compare line differences, but we should also check to make sure the lengths of lines are equal.