### PR TITLE
Issue #705: Cannot delete image

### DIFF
--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Bugs addressed in this release:
 * [#690](../../issues/690) ASAN crash when you close a show with X and then reopen
 * [#702](../../issues/702) libcurl is not found on windows
 * [#704](../../issues/704) Reset All in Settings doesn't seem to be working
+* [#705](../../issues/705) Cannot delete image
 
 Other changes:
 

--- a/src/BackgroundImages.cpp
+++ b/src/BackgroundImages.cpp
@@ -335,9 +335,12 @@ BackgroundImages::~BackgroundImages() = default;
 
 void BackgroundImages::SetBackgroundImages(std::vector<CalChart::ImageInfo> const& images)
 {
+    auto previousSize = mBackgroundImages.size();
     mBackgroundImages = CalChart::Ranges::ToVector<BackgroundImage>(
         images | std::views::transform([](auto&& image) { return BackgroundImage{ image }; }));
-    mWhichBackgroundIndex = std::nullopt;
+    if (mBackgroundImages.size() != previousSize) {
+        mWhichBackgroundIndex = std::nullopt;
+    }
 }
 
 void BackgroundImages::OnPaint(wxDC& dc) const


### PR DESCRIPTION
Looks like everytime we update the current images, we clear the image index.  That basically happens after you complete a move, which means you effectively can never update the image.