### PR TITLE
Issue #783: Why are we crashing in the Continuity editor

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,12 +21,10 @@
             "description": "Mac Release build with Ninja",
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/mac-release",
-            "environment": {
-                "VCPKG_TARGET_TRIPLET": "arm64-osx"
-            },
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_TARGET_TRIPLET": "arm64-osx"
             }
         },
         {
@@ -35,12 +33,11 @@
             "description": "Mac Debug build with Ninja",
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/mac-debug",
-            "environment": {
-                "VCPKG_TARGET_TRIPLET": "arm64-osx-debug"
-            },
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/vcpkg-triplets",
+                "VCPKG_TARGET_TRIPLET": "arm64-osx-asan"
             }
         }
     ],

--- a/LATEST_RELEASE_NOTES.md
+++ b/LATEST_RELEASE_NOTES.md
@@ -10,4 +10,5 @@ Other changes:
 * [#773](../../issues/773) Add the minimal integration of CalChart-Viewer
 * [#775](../../issues/775) Don't bother signing debug versions of calchart
 * [#781](../../issues/781) Add per sheet tempo
+* [#783](../../issues/783) Why are we crashing in the Continuity editor
 

--- a/vcpkg-triplets/arm64-osx-asan.cmake
+++ b/vcpkg-triplets/arm64-osx-asan.cmake
@@ -1,0 +1,11 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+
+# Keep sanitizer instrumentation aligned between the app and vcpkg dependencies.
+set(VCPKG_C_FLAGS_DEBUG "${VCPKG_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer")
+set(VCPKG_CXX_FLAGS_DEBUG "${VCPKG_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer")
+set(VCPKG_LINKER_FLAGS_DEBUG "${VCPKG_LINKER_FLAGS_DEBUG} -fsanitize=address")


### PR DESCRIPTION
Due to mis-match between vcpkg build settings.